### PR TITLE
Remove deprecated space separator for files

### DIFF
--- a/coverage/README.md
+++ b/coverage/README.md
@@ -10,7 +10,7 @@ A GitHub Action for running code coverage analysis using the qlty tool.
 |-------|-------------|----------|---------|
 | `coverage-token` | Authentication token for coverage submission | Yes | - |
 | `files` | Files to process (supports glob patterns and comma-separated paths) | Yes | - |
-| `print-coverage` | Display coverage information in the logs | No | `false` |
+| `verbose` | Display debug logs along with coverage data | No | `false` |
 | `print-json-coverage` | Output coverage data in JSON format | No | `false` |
 | `add-prefix` | Prefix to add to file paths | No | - |
 | `strip-prefix` | Prefix to remove from file paths | No | - |

--- a/coverage/README.md
+++ b/coverage/README.md
@@ -14,7 +14,7 @@ A GitHub Action for running code coverage analysis using the qlty tool.
 | `print-json-coverage` | Output coverage data in JSON format | No | `false` |
 | `add-prefix` | Prefix to add to file paths | No | - |
 | `strip-prefix` | Prefix to remove from file paths | No | - |
-| `skip-errors` | Continue execution even if errors occur | No | `false` |
+| `skip-errors` | Continue execution even if errors occur | No | `true` |
 | `skip-missing-files` | Files not in the directory are skipped | No | `false` |
 | `tag` | Tag to associate with the coverage data | No | - |
 

--- a/coverage/README.md
+++ b/coverage/README.md
@@ -11,7 +11,6 @@ A GitHub Action for running code coverage analysis using the qlty tool.
 | `coverage-token` | Authentication token for coverage submission | Yes | - |
 | `files` | Files to process (supports glob patterns and comma-separated paths) | Yes | - |
 | `verbose` | Display debug logs along with coverage data | No | `false` |
-| `print-json-coverage` | Output coverage data in JSON format | No | `false` |
 | `add-prefix` | Prefix to add to file paths | No | - |
 | `strip-prefix` | Prefix to remove from file paths | No | - |
 | `skip-errors` | Continue execution even if errors occur | No | `true` |

--- a/coverage/action.yml
+++ b/coverage/action.yml
@@ -30,8 +30,8 @@ inputs:
     required: false
     default: ''
 
-  print-coverage:
-    description: 'Print the coverage data before uploading'
+  verbose:
+    description: 'Verbose output for debugging'
     required: false
     default: 'false'
 

--- a/coverage/action.yml
+++ b/coverage/action.yml
@@ -35,11 +35,6 @@ inputs:
     required: false
     default: 'false'
 
-  print-json-coverage:
-    description: 'Print the coverage data before uploading as JSON'
-    required: false
-    default: 'false'
-
   skip-errors:
     description: 'Do not error the action if the upload fails'
     required: false

--- a/coverage/action.yml
+++ b/coverage/action.yml
@@ -43,7 +43,7 @@ inputs:
   skip-errors:
     description: 'Do not error the action if the upload fails'
     required: false
-    default: 'false'
+    default: 'true'
 
   skip-missing-files:
     description: 'Files not in the directory are skipped'

--- a/coverage/dist/index.js
+++ b/coverage/dist/index.js
@@ -45380,20 +45380,12 @@ async function run() {
   const binPath = `${cachedPath}/qlty-${platformArch}`;
   core.addPath(binPath);
   const rawFiles = core.getInput("files", { required: true }).trim();
-  let patterns = [];
-  if (rawFiles.includes(" ")) {
-    core.warning(
-      'Space-separated file patterns for files input are deprecated and will be removed in a future version. Please use commas, e.g., "fileA.js,fileB.js"'
-    );
-    patterns = rawFiles.split(" ");
-  } else {
-    patterns = rawFiles.split(",").map((file) => file.trim()).filter(Boolean);
-  }
+  let patterns = rawFiles.split(",").map((file) => file.trim()).filter(Boolean);
   const patternString = patterns.join("\n");
   const globber = await glob.create(patternString);
   let expandedFiles = await globber.glob();
   expandedFiles = Array.from(new Set(expandedFiles));
-  const printCoverage = core.getBooleanInput("print-coverage");
+  const verbose = core.getBooleanInput("verbose");
   const printJsonCoverage = core.getBooleanInput("print-json-coverage");
   const addPrefix = core.getInput("add-prefix");
   const stripPrefix = core.getInput("strip-prefix");
@@ -45401,7 +45393,7 @@ async function run() {
   const skipMissingFiles = core.getBooleanInput("skip-missing-files");
   const tag = core.getInput("tag");
   let uploadArgs = ["coverage", "publish"];
-  if (printCoverage) {
+  if (verbose) {
     uploadArgs.push("--print");
   }
   if (printJsonCoverage) {

--- a/coverage/dist/index.js
+++ b/coverage/dist/index.js
@@ -45386,7 +45386,6 @@ async function run() {
   let expandedFiles = await globber.glob();
   expandedFiles = Array.from(new Set(expandedFiles));
   const verbose = core.getBooleanInput("verbose");
-  const printJsonCoverage = core.getBooleanInput("print-json-coverage");
   const addPrefix = core.getInput("add-prefix");
   const stripPrefix = core.getInput("strip-prefix");
   const skipErrors = core.getBooleanInput("skip-errors");
@@ -45395,9 +45394,6 @@ async function run() {
   let uploadArgs = ["coverage", "publish"];
   if (verbose) {
     uploadArgs.push("--print");
-  }
-  if (printJsonCoverage) {
-    uploadArgs.push("--json");
   }
   if (addPrefix) {
     uploadArgs.push("--transform-add-prefix", addPrefix);

--- a/coverage/src/main.ts
+++ b/coverage/src/main.ts
@@ -97,20 +97,10 @@ async function run(): Promise<void> {
 
   const rawFiles = core.getInput('files', { required: true }).trim()
 
-  let patterns: string[] = []
-
-  if (rawFiles.includes(' ')) {
-    core.warning(
-      'Space-separated file patterns for files input are deprecated and will be removed in a future version. ' +
-        'Please use commas, e.g., "fileA.js,fileB.js"'
-    )
-    patterns = rawFiles.split(' ')
-  } else {
-    patterns = rawFiles
-      .split(',')
-      .map(file => file.trim())
-      .filter(Boolean)
-  }
+  let patterns: string[] = rawFiles
+    .split(',')
+    .map(file => file.trim())
+    .filter(Boolean)
 
   const patternString = patterns.join('\n')
   const globber = await glob.create(patternString)

--- a/coverage/src/main.ts
+++ b/coverage/src/main.ts
@@ -108,7 +108,6 @@ async function run(): Promise<void> {
   expandedFiles = Array.from(new Set(expandedFiles))
 
   const verbose = core.getBooleanInput('verbose')
-  const printJsonCoverage = core.getBooleanInput('print-json-coverage')
   const addPrefix = core.getInput('add-prefix')
   const stripPrefix = core.getInput('strip-prefix')
   const skipErrors = core.getBooleanInput('skip-errors')
@@ -119,10 +118,6 @@ async function run(): Promise<void> {
 
   if (verbose) {
     uploadArgs.push('--print')
-  }
-
-  if (printJsonCoverage) {
-    uploadArgs.push('--json')
   }
 
   if (addPrefix) {

--- a/coverage/src/main.ts
+++ b/coverage/src/main.ts
@@ -107,7 +107,7 @@ async function run(): Promise<void> {
   let expandedFiles = await globber.glob()
   expandedFiles = Array.from(new Set(expandedFiles))
 
-  const printCoverage = core.getBooleanInput('print-coverage')
+  const verbose = core.getBooleanInput('verbose')
   const printJsonCoverage = core.getBooleanInput('print-json-coverage')
   const addPrefix = core.getInput('add-prefix')
   const stripPrefix = core.getInput('strip-prefix')
@@ -117,7 +117,7 @@ async function run(): Promise<void> {
 
   let uploadArgs = ['coverage', 'publish']
 
-  if (printCoverage) {
+  if (verbose) {
     uploadArgs.push('--print')
   }
 

--- a/coverage/tests/main.test.ts
+++ b/coverage/tests/main.test.ts
@@ -199,25 +199,4 @@ describe('Coverage Action - main.ts', () => {
     expect(args.filter(arg => arg === 'src/main.ts').length).toBe(1)
     expect(args).toContain('src/utils.ts')
   })
-
-  it('should handle space-separated patterns but log a deprecation warning', async () => {
-    getInputSpy.mockImplementation((name: string) => {
-      if (name === 'coverage-token') return 'abc123'
-      if (name === 'files') return 'src/main.ts src/**/*.ts'
-      return ''
-    })
-    vi.mocked(core.getBooleanInput).mockReturnValue(false)
-
-    await runWithTracing()
-
-    expect(core.warning).toHaveBeenCalledWith(
-      expect.stringContaining('deprecated')
-    )
-
-    expect(exec.exec).toHaveBeenCalled()
-    const [tool, args] = vi.mocked(exec.exec).mock.calls[0]
-    expect(tool).toBe('qlty')
-    expect(args).toContain('src/main.ts')
-    expect(args).toContain('src/utils.ts')
-  })
 })


### PR DESCRIPTION
This PR:
1. Removes deprecated space separator for files
2. Renames print-coverage to verbose
3. Changes skip-error default to true