### PR TITLE
Add support for new qlty coverage publish --total-parts-count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/node_modules/*
+coverage/.qlty

--- a/coverage/action.yml
+++ b/coverage/action.yml
@@ -51,6 +51,11 @@ inputs:
     required: false
     default: false
 
+  total-parts-count:
+    description:
+      'The total number of coverage uploads that qlty cloud should expect'
+    required: false
+
 runs:
   using: node20
   main: dist/index.js

--- a/coverage/dist/index.js
+++ b/coverage/dist/index.js
@@ -69193,6 +69193,7 @@ async function run() {
   const skipErrors = core.getBooleanInput("skip-errors");
   const skipMissingFiles = core.getBooleanInput("skip-missing-files");
   const tag = core.getInput("tag");
+  const totalPartsCount = core.getInput("total-parts-count");
   let uploadArgs = ["coverage", "publish"];
   if (verbose) {
     uploadArgs.push("--print");
@@ -69205,6 +69206,9 @@ async function run() {
   }
   if (tag) {
     uploadArgs.push("--tag", tag);
+  }
+  if (totalPartsCount) {
+    uploadArgs.push("--total-parts-count", totalPartsCount);
   }
   if (context3.payload.pull_request) {
     uploadArgs.push(

--- a/coverage/src/main.ts
+++ b/coverage/src/main.ts
@@ -112,6 +112,7 @@ async function run(): Promise<void> {
   const skipErrors = core.getBooleanInput('skip-errors')
   const skipMissingFiles = core.getBooleanInput('skip-missing-files')
   const tag = core.getInput('tag')
+  const totalPartsCount = core.getInput('total-parts-count')
 
   let uploadArgs = ['coverage', 'publish']
 
@@ -129,6 +130,10 @@ async function run(): Promise<void> {
 
   if (tag) {
     uploadArgs.push('--tag', tag)
+  }
+
+  if (totalPartsCount) {
+    uploadArgs.push('--total-parts-count', totalPartsCount)
   }
 
   // Github doesn't provide the head's sha for PRs, so we need to extract it from the event's payload

--- a/coverage/tests/main.test.ts
+++ b/coverage/tests/main.test.ts
@@ -215,4 +215,19 @@ describe('Coverage Action - main.ts', () => {
     expect(args).toContain('--total-parts-count')
     expect(args).toContain('44')
   })
+
+  it('should pass not define total-parts-count if input is not provided', async () => {
+    getInputSpy.mockImplementation((name: string) => {
+      if (name === 'total-parts-count') return ''
+
+      return ''
+    })
+
+    await runWithTracing()
+
+    expect(exec.exec).toHaveBeenCalled()
+    const [_, args] = vi.mocked(exec.exec).mock.calls[0]
+
+    expect(args).not.toContain('--total-parts-count')
+  })
 })

--- a/coverage/tests/main.test.ts
+++ b/coverage/tests/main.test.ts
@@ -210,7 +210,7 @@ describe('Coverage Action - main.ts', () => {
     await runWithTracing()
 
     expect(exec.exec).toHaveBeenCalled()
-    const [_, args] = vi.mocked(exec.exec).mock.calls[0]
+    const [, args] = vi.mocked(exec.exec).mock.calls[0]
 
     expect(args).toContain('--total-parts-count')
     expect(args).toContain('44')

--- a/coverage/tests/main.test.ts
+++ b/coverage/tests/main.test.ts
@@ -212,11 +212,7 @@ describe('Coverage Action - main.ts', () => {
     expect(exec.exec).toHaveBeenCalled()
     const [_, args] = vi.mocked(exec.exec).mock.calls[0]
 
-    const defined_args = args || []
-    const index = defined_args.indexOf('--total-parts-count')
-    expect(defined_args.slice(index, index + 2)).toEqual([
-      '--total-parts-count',
-      '44'
-    ])
+    expect(args).toContain('--total-parts-count')
+    expect(args).toContain('44')
   })
 })

--- a/coverage/tests/main.test.ts
+++ b/coverage/tests/main.test.ts
@@ -96,7 +96,7 @@ describe('Coverage Action - main.ts', () => {
     vi.mocked(tc.cacheDir).mockResolvedValue('/tmp/cached-qlty')
   })
 
-  it('should succeedwith a non-glob path', async () => {
+  it('should succeed with a non-glob path', async () => {
     getInputSpy.mockImplementation((name: string) => {
       if (name === 'coverage-token') return 'abc123'
       if (name === 'files') return 'src/main.ts'
@@ -198,5 +198,25 @@ describe('Coverage Action - main.ts', () => {
     expect(tool).toBe('qlty')
     expect(args.filter(arg => arg === 'src/main.ts').length).toBe(1)
     expect(args).toContain('src/utils.ts')
+  })
+
+  it('should pass along total-parts-count', async () => {
+    getInputSpy.mockImplementation((name: string) => {
+      if (name === 'total-parts-count') return '44'
+
+      return ''
+    })
+
+    await runWithTracing()
+
+    expect(exec.exec).toHaveBeenCalled()
+    const [_, args] = vi.mocked(exec.exec).mock.calls[0]
+
+    const defined_args = args || []
+    const index = defined_args.indexOf('--total-parts-count')
+    expect(defined_args.slice(index, index + 2)).toEqual([
+      '--total-parts-count',
+      '44'
+    ])
   })
 })


### PR DESCRIPTION
See title.

This _should_ be a no op if this new option is not provided which, from day 1, will be everyone. According to the GitHub Actions Core package source comment/code `core.getInput("foo")` will returns an empty string if not defined:

https://github.com/actions/toolkit/blob/main/packages/core/src/core.ts#L145

So should be a no op, unless defined. If defined improperly, the qlty cli should complain, so no input validation is being done here.