### PR TITLE
Validate format of coverage tokens

### DIFF
--- a/coverage/src/action.ts
+++ b/coverage/src/action.ts
@@ -62,7 +62,22 @@ export class CoverageAction {
   }
 
   async run(): Promise<void> {
-    this._settings.validate();
+    const errors = this._settings.validate();
+
+    if (errors.length > 0) {
+      if (this._settings.input.skipErrors) {
+        this._output.warning("Error validating action input:");
+
+        for (const error of errors) {
+          this._output.warning(error);
+        }
+      } else {
+        throw new CoverageSettingsValidationError(errors.join("; "));
+      }
+
+      return;
+    }
+
     await this._installer.install();
 
     const uploadArgs = await this.buildArgs();
@@ -92,7 +107,7 @@ export class CoverageAction {
     } catch {
       if (this._settings.input.skipErrors) {
         this._output.warning(
-          "Error uploading coverage, skipping due to skip-errors",
+          "Error uploading coverage, skipping due to skip-errors"
         );
         this._output.warning("Output:");
         this._output.warning(qlytOutput);
@@ -116,7 +131,7 @@ export class CoverageAction {
     if (this._settings.input.stripPrefix) {
       uploadArgs.push(
         "--transform-strip-prefix",
-        this._settings.input.stripPrefix,
+        this._settings.input.stripPrefix
       );
     }
 
@@ -127,7 +142,7 @@ export class CoverageAction {
     if (this._settings.input.totalPartsCount) {
       uploadArgs.push(
         "--total-parts-count",
-        this._settings.input.totalPartsCount.toString(),
+        this._settings.input.totalPartsCount.toString()
       );
     }
 
@@ -139,7 +154,7 @@ export class CoverageAction {
     if (payload.pull_request) {
       uploadArgs.push(
         "--override-commit-sha",
-        payload.pull_request["head"].sha,
+        payload.pull_request["head"].sha
       );
       uploadArgs.push("--override-branch", payload.pull_request["head"].ref);
     }
@@ -157,6 +172,13 @@ export class CoverageAction {
       command: string;
       env: Record<string, string>;
     }>(this._emitter, EXEC_EVENT);
+  }
+}
+
+export class CoverageSettingsValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CoverageSettingsValidationError";
   }
 }
 

--- a/coverage/tests/settings.test.ts
+++ b/coverage/tests/settings.test.ts
@@ -3,7 +3,7 @@ import { Settings } from "src/settings";
 describe("Settings", () => {
   test("parses values", () => {
     const settings = Settings.createNull({
-      "coverage-token": "test-token",
+      "coverage-token": "qltcp_1234567890",
       files: "  whitespace  ",
       "add-prefix": "test-prefix",
       "strip-prefix": "test-strip-prefix",
@@ -16,7 +16,7 @@ describe("Settings", () => {
     });
 
     expect(settings.input).toMatchObject({
-      coverageToken: "test-token",
+      coverageToken: "qltcp_1234567890",
       files: "whitespace",
       addPrefix: "test-prefix",
       stripPrefix: "test-strip-prefix",
@@ -51,21 +51,27 @@ describe("Settings", () => {
 
   describe("validation", () => {
     test("allows valid cases", () => {
-      Settings.createNull({
-        "coverage-token": "coverage-token",
-        oidc: false,
-      }).validate();
+      expect(
+        Settings.createNull({
+          "coverage-token": "qltcp_1234567890",
+          oidc: false,
+        }).validate()
+      ).toEqual([]);
 
-      Settings.createNull({
-        token: "token",
-        oidc: false,
-      }).validate();
+      expect(
+        Settings.createNull({
+          token: "qltcp_1234567890",
+          oidc: false,
+        }).validate()
+      ).toEqual([]);
 
-      Settings.createNull({
-        "coverage-token": "",
-        token: "",
-        oidc: true,
-      }).validate();
+      expect(
+        Settings.createNull({
+          "coverage-token": "",
+          token: "",
+          oidc: true,
+        }).validate()
+      ).toEqual([]);
     });
 
     test("fails when OIDC and token are both missing", () => {
@@ -74,20 +80,44 @@ describe("Settings", () => {
         oidc: false,
       });
 
-      expect(() => settings.validate()).toThrow(
+      expect(settings.validate()).toEqual([
         "Either 'oidc' or 'token' must be provided.",
-      );
+      ]);
     });
 
     test("fails when OIDC and token are both present", () => {
       const settings = Settings.createNull({
-        token: "test-token",
+        token: "qltcp_1234567890",
         oidc: true,
       });
 
-      expect(() => settings.validate()).toThrow(
+      expect(settings.validate()).toEqual([
         "Both 'oidc' and 'token' cannot be provided at the same time.",
-      );
+      ]);
+    });
+
+    test("validates token", () => {
+      expect(
+        Settings.createNull({
+          token: "wrong",
+        }).validate()
+      ).toEqual([
+        "The provided token is invalid. It should begin with 'qltcp_' or 'qltcw_' followed by alphanumerics.",
+      ]);
+
+      expect(
+        Settings.createNull({
+          "coverage-token": "wrong",
+        }).validate()
+      ).toEqual([
+        "The provided token is invalid. It should begin with 'qltcp_' or 'qltcw_' followed by alphanumerics.",
+      ]);
+
+      expect(
+        Settings.createNull({
+          "coverage-token": "qltcp_1234567890",
+        }).validate()
+      ).toEqual([]);
     });
   });
 
@@ -110,10 +140,10 @@ describe("Settings", () => {
   describe("getToken", () => {
     test("returns the token", async () => {
       const settings = Settings.createNull({
-        token: "test-token",
+        token: "qltcp_1234567890",
         oidc: false,
       });
-      expect(await settings.getToken()).toEqual("test-token");
+      expect(await settings.getToken()).toEqual("qltcp_1234567890");
     });
 
     test("returns the coverage token", async () => {
@@ -127,11 +157,11 @@ describe("Settings", () => {
 
     test("prefers token over coverage-token", async () => {
       const settings = Settings.createNull({
-        token: "test-token",
+        token: "qltcp_1234567890",
         "coverage-token": "test-coverage-token",
         oidc: false,
       });
-      expect(await settings.getToken()).toEqual("test-token");
+      expect(await settings.getToken()).toEqual("qltcp_1234567890");
     });
 
     test("generates an ID token", async () => {
@@ -141,7 +171,7 @@ describe("Settings", () => {
       });
 
       expect(await settings.getToken()).toEqual(
-        "oidc-token:audience=https://qlty.sh",
+        "oidc-token:audience=https://qlty.sh"
       );
     });
 
@@ -153,7 +183,7 @@ describe("Settings", () => {
       });
 
       await expect(settings.getToken()).rejects.toThrow(
-        "'token' is required when 'oidc' is false.",
+        "'token' is required when 'oidc' is false."
       );
     });
   });


### PR DESCRIPTION
Valid coverage tokens always follow a known format:

- Begin with `qltcp_` for project tokens
- Begin with `qltcw_` for workspace tokens
- Followed by random alphanumeric characters (currently 16, but this format validation only looks for 10+)