### PR TITLE
Add dry-run input parameter

### DIFF
--- a/coverage/README.md
+++ b/coverage/README.md
@@ -86,6 +86,7 @@ The Qlty Cloud offers free plans, including for commercial projects, with no lim
 | `skip-errors`        | If coverage upload fails, do not fail the CI build occur                                                                                                                                                               | No       | `true`  |
 | `skip-missing-files` | Files not in the directory are skipped                                                                                                                                                                                 | No       | `false` |
 | `tag`                | Tag to associate with the coverage data                                                                                                                                                                                | No       | -       |
+| `dry-run`            | Run in dry run mode without uploading coverage data                                                                                                                                                                    | No       | `false` |
 | `cli-version`        | Specific version of the Qlty CLI to use (e.g., '1.0.1'). If not specified, will install the latest version.s                                                                                                           | No       |         |
 
 ---

--- a/coverage/action.yml
+++ b/coverage/action.yml
@@ -83,6 +83,11 @@ inputs:
     required: false
     default: ""
 
+  dry-run:
+    description: "Run in dry run mode without uploading coverage data"
+    required: false
+    default: false
+
 runs:
   using: node20
   main: dist/index.js

--- a/coverage/dist/index.js
+++ b/coverage/dist/index.js
@@ -73562,7 +73562,8 @@ var settingsParser = z.object({
   oidc: z.boolean(),
   verbose: z.boolean(),
   cliVersion: optionalNormalizedString,
-  format: z.union([formatEnum, z.literal("")]).transform((val) => val === "" ? void 0 : val).optional()
+  format: z.union([formatEnum, z.literal("")]).transform((val) => val === "" ? void 0 : val).optional(),
+  dryRun: z.boolean()
 });
 var OIDC_AUDIENCE = "https://qlty.sh";
 var COVERAGE_TOKEN_REGEX = /^(qltcp_|qltcw_)[a-zA-Z0-9]{10,}$/;
@@ -73590,7 +73591,8 @@ var Settings = class _Settings {
         token: input.getInput("token"),
         verbose: input.getBooleanInput("verbose"),
         cliVersion: input.getInput("cli-version"),
-        format: input.getInput("format")
+        format: input.getInput("format"),
+        dryRun: input.getBooleanInput("dry-run")
       }),
       input,
       fs
@@ -73697,7 +73699,8 @@ var StubbedInputProvider = class {
       token: data.token || "",
       verbose: data.verbose || false,
       "cli-version": data["cli-version"] || "",
-      format: data["format"] || ""
+      format: data["format"] || "",
+      "dry-run": data["dry-run"] || false
     };
   }
   getInput(name, _options) {
@@ -73877,6 +73880,9 @@ var CoverageAction = class _CoverageAction {
     const uploadArgs = ["coverage", "publish"];
     if (this._settings.input.verbose) {
       uploadArgs.push("--print");
+    }
+    if (this._settings.input.dryRun) {
+      uploadArgs.push("--dry-run");
     }
     if (this._settings.input.addPrefix) {
       uploadArgs.push("--add-prefix", this._settings.input.addPrefix);

--- a/coverage/src/action.ts
+++ b/coverage/src/action.ts
@@ -168,6 +168,10 @@ export class CoverageAction {
       uploadArgs.push("--print");
     }
 
+    if (this._settings.input.dryRun) {
+      uploadArgs.push("--dry-run");
+    }
+
     if (this._settings.input.addPrefix) {
       uploadArgs.push("--add-prefix", this._settings.input.addPrefix);
     }

--- a/coverage/src/settings.ts
+++ b/coverage/src/settings.ts
@@ -26,6 +26,7 @@ interface ActionInputKeys {
   verbose: boolean;
   "cli-version": string;
   format: string;
+  "dry-run": boolean;
 }
 
 const optionalNormalizedString = z
@@ -65,6 +66,7 @@ const settingsParser = z.object({
     .union([formatEnum, z.literal("")])
     .transform((val) => (val === "" ? undefined : val))
     .optional(),
+  dryRun: z.boolean(),
 });
 
 export type SettingsOutput = z.output<typeof settingsParser>;
@@ -96,6 +98,7 @@ export class Settings {
         verbose: input.getBooleanInput("verbose"),
         cliVersion: input.getInput("cli-version"),
         format: input.getInput("format"),
+        dryRun: input.getBooleanInput("dry-run"),
       }),
       input,
       fs,
@@ -244,6 +247,7 @@ export class StubbedInputProvider implements InputProvider {
       verbose: data.verbose || false,
       "cli-version": data["cli-version"] || "",
       format: data["format"] || "",
+      "dry-run": data["dry-run"] || false,
     };
   }
 

--- a/coverage/tests/action.test.ts
+++ b/coverage/tests/action.test.ts
@@ -95,6 +95,7 @@ describe("CoverageAction", () => {
         "strip-prefix": "strip",
         format: "simplecov",
         verbose: true,
+        "dry-run": true,
       }),
       context: { payload: {} },
     });
@@ -109,6 +110,7 @@ describe("CoverageAction", () => {
       "coverage",
       "publish",
       "--print",
+      "--dry-run",
       "--add-prefix",
       "prefix",
       "--strip-prefix",

--- a/coverage/tests/settings.test.ts
+++ b/coverage/tests/settings.test.ts
@@ -15,6 +15,7 @@ describe("Settings", () => {
       verbose: true,
       "cli-version": "1.2.3",
       format: "simplecov",
+      "dry-run": true,
     });
 
     expect(settings.input).toMatchObject({
@@ -30,6 +31,7 @@ describe("Settings", () => {
       verbose: true,
       cliVersion: "1.2.3",
       format: "simplecov",
+      dryRun: true,
     });
   });
 
@@ -51,6 +53,7 @@ describe("Settings", () => {
       stripPrefix: undefined,
       totalPartsCount: undefined,
       format: undefined,
+      dryRun: false,
     });
   });
 


### PR DESCRIPTION
## Summary
- Add new dry-run input flag with default value of false
- This allows users to run the action in dry-run mode to test configuration without actually uploading coverage data

## Test plan
- Added test coverage in both settings.test.ts and action.test.ts
- All unit tests pass successfully
- Manually tested by running npm run all

🤖 Generated with [Claude Code](https://claude.ai/code)