### PR TITLE
Add name input option to coverage action

### DIFF
--- a/coverage/README.md
+++ b/coverage/README.md
@@ -88,6 +88,7 @@ The Qlty Cloud offers free plans, including for commercial projects, with no lim
 | `tag`                | Tag to associate with the coverage data                                                                                                                                                                                | No       | -       |
 | `cli-version`        | Specific version of the Qlty CLI to use (e.g., '1.0.1'). If not specified, will install the latest version.                                                                                                            | No       |         |
 | `incomplete`         | Mark the coverage data as incomplete                                                                                                                                                                                   | No       | `false` |
+| `name`               | Name to identify this coverage upload                                                                                                                                                                                  | No       | -       |
 
 ---
 

--- a/coverage/action.yml
+++ b/coverage/action.yml
@@ -93,6 +93,11 @@ inputs:
     required: false
     default: false
 
+  name:
+    description: "The name to identify this coverage upload"
+    required: false
+    default: ""
+
 runs:
   using: node20
   main: dist/index.js

--- a/coverage/dist/index.js
+++ b/coverage/dist/index.js
@@ -73564,7 +73564,8 @@ var settingsParser = z.object({
   cliVersion: optionalNormalizedString,
   format: z.union([formatEnum, z.literal("")]).transform((val) => val === "" ? void 0 : val).optional(),
   dryRun: z.boolean(),
-  incomplete: z.boolean()
+  incomplete: z.boolean(),
+  name: optionalNormalizedString
 });
 var OIDC_AUDIENCE = "https://qlty.sh";
 var COVERAGE_TOKEN_REGEX = /^(qltcp_|qltcw_)[a-zA-Z0-9]{10,}$/;
@@ -73594,7 +73595,8 @@ var Settings = class _Settings {
         cliVersion: input.getInput("cli-version"),
         format: input.getInput("format"),
         dryRun: input.getBooleanInput("dry-run"),
-        incomplete: input.getBooleanInput("incomplete")
+        incomplete: input.getBooleanInput("incomplete"),
+        name: input.getInput("name")
       }),
       input,
       fs
@@ -73703,7 +73705,8 @@ var StubbedInputProvider = class {
       "cli-version": data["cli-version"] || "",
       format: data["format"] || "",
       "dry-run": data["dry-run"] || false,
-      incomplete: data.incomplete || false
+      incomplete: data.incomplete || false,
+      name: data.name || ""
     };
   }
   getInput(name, _options) {
@@ -73918,6 +73921,9 @@ var CoverageAction = class _CoverageAction {
     }
     if (this._settings.input.incomplete) {
       uploadArgs.push("--incomplete");
+    }
+    if (this._settings.input.name) {
+      uploadArgs.push("--name", this._settings.input.name);
     }
     return uploadArgs;
   }

--- a/coverage/src/action.ts
+++ b/coverage/src/action.ts
@@ -216,6 +216,10 @@ export class CoverageAction {
       uploadArgs.push("--incomplete");
     }
 
+    if (this._settings.input.name) {
+      uploadArgs.push("--name", this._settings.input.name);
+    }
+
     return uploadArgs;
   }
 

--- a/coverage/src/settings.ts
+++ b/coverage/src/settings.ts
@@ -28,6 +28,7 @@ interface ActionInputKeys {
   format: string;
   "dry-run": boolean;
   incomplete: boolean;
+  name: string;
 }
 
 const optionalNormalizedString = z
@@ -69,6 +70,7 @@ const settingsParser = z.object({
     .optional(),
   dryRun: z.boolean(),
   incomplete: z.boolean(),
+  name: optionalNormalizedString,
 });
 
 export type SettingsOutput = z.output<typeof settingsParser>;
@@ -102,6 +104,7 @@ export class Settings {
         format: input.getInput("format"),
         dryRun: input.getBooleanInput("dry-run"),
         incomplete: input.getBooleanInput("incomplete"),
+        name: input.getInput("name"),
       }),
       input,
       fs,
@@ -252,6 +255,7 @@ export class StubbedInputProvider implements InputProvider {
       format: data["format"] || "",
       "dry-run": data["dry-run"] || false,
       incomplete: data.incomplete || false,
+      name: data.name || "",
     };
   }
 

--- a/coverage/tests/action.test.ts
+++ b/coverage/tests/action.test.ts
@@ -97,6 +97,7 @@ describe("CoverageAction", () => {
         verbose: true,
         "dry-run": true,
         incomplete: true,
+        name: "test-name",
       }),
       context: { payload: {} },
     });
@@ -124,6 +125,8 @@ describe("CoverageAction", () => {
       "5",
       "--skip-missing-files",
       "--incomplete",
+      "--name",
+      "test-name",
       "info.lcov",
     ]);
     expect(command?.env).toMatchObject({
@@ -174,6 +177,24 @@ describe("CoverageAction", () => {
     expect(executedCommands.length).toBe(1);
     const command = executedCommands[0];
     expect(command?.command).toContain("--incomplete");
+  });
+
+  test("adds name argument when name is provided", async () => {
+    const { action, commands } = createTrackedAction({
+      settings: Settings.createNull({
+        "coverage-token": "qltcp_1234567890",
+        files: "info.lcov",
+        name: "custom-name",
+      }),
+      context: { payload: {} },
+    });
+    await action.run();
+
+    const executedCommands = commands.clear();
+    expect(executedCommands.length).toBe(1);
+    const command = executedCommands[0];
+    expect(command?.command).toContain("--name");
+    expect(command?.command).toContain("custom-name");
   });
 
   describe("error handling", () => {

--- a/coverage/tests/settings.test.ts
+++ b/coverage/tests/settings.test.ts
@@ -17,6 +17,7 @@ describe("Settings", () => {
       format: "simplecov",
       "dry-run": true,
       incomplete: true,
+      name: "test-name",
     });
 
     expect(settings.input).toMatchObject({
@@ -34,6 +35,7 @@ describe("Settings", () => {
       format: "simplecov",
       dryRun: true,
       incomplete: true,
+      name: "test-name",
     });
   });
 
@@ -46,6 +48,7 @@ describe("Settings", () => {
       tag: "",
       "total-parts-count": "",
       incomplete: false,
+      name: "",
     });
 
     expect(settings.input).toMatchObject({
@@ -58,6 +61,7 @@ describe("Settings", () => {
       format: undefined,
       dryRun: false,
       incomplete: false,
+      name: undefined,
     });
   });
 


### PR DESCRIPTION
## Summary
- Add new 'name' input parameter that defaults to an empty string
- When 'name' is provided, add `--name [NAME]` flag to the CLI command arguments
- Add test coverage for the new option
- Update documentation in README.md

## Test plan
- Verified all tests pass
- Verified TypeScript compilation is successful
- Verified the build process is successful

🤖 Generated with [Claude Code](https://claude.ai/code)