### PR TITLE
Allow dry-run without authentication

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   pull_request:
   push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/coverage/src/action.ts
+++ b/coverage/src/action.ts
@@ -102,17 +102,22 @@ export class CoverageAction {
     uploadArgs = uploadArgs.concat(files);
 
     const token = await this._settings.getToken();
-    this._output.setSecret(token);
+    if (token) {
+      this._output.setSecret(token);
+    }
 
     let qlytOutput = "";
 
     try {
-      const env = {
+      const env: Record<string, string> = {
         ...process.env,
-        QLTY_COVERAGE_TOKEN: token,
         QLTY_CI_UPLOADER_TOOL: "qltysh/qlty-action",
         QLTY_CI_UPLOADER_VERSION: Version.readVersion() || "",
       };
+
+      if (token) {
+        env["QLTY_COVERAGE_TOKEN"] = token;
+      }
 
       this._emitter.emit(EXEC_EVENT, { command: ["qlty", ...uploadArgs], env });
       this._output.info(`Running: ${["qlty", ...uploadArgs].join(" ")}`);

--- a/coverage/src/settings.ts
+++ b/coverage/src/settings.ts
@@ -151,9 +151,10 @@ export class Settings {
   }
 
   async getToken(): Promise<string | null> {
-    // For dry runs, we can return null when no authentication is provided
     if (this._data.dryRun) {
       if (this._data.oidc) {
+        // When running in dry-run mode with oidc, we still generate an OIDC token
+        // This ensures the workflow is authorized to use OIDC.
         return await this._input.getIDToken(OIDC_AUDIENCE);
       } else {
         const coverageToken = this.getCoverageToken();

--- a/coverage/src/settings.ts
+++ b/coverage/src/settings.ts
@@ -128,26 +128,39 @@ export class Settings {
     const errors = [];
     const coverageToken = this.getCoverageToken();
 
-    if (!this._data.oidc && !coverageToken) {
-      errors.push("Either 'oidc' or 'token' must be provided.");
-    }
+    // Skip token validation when in dry-run mode
+    if (!this._data.dryRun) {
+      if (!this._data.oidc && !coverageToken) {
+        errors.push("Either 'oidc' or 'token' must be provided.");
+      }
 
-    if (this._data.oidc && coverageToken) {
-      errors.push(
-        "Both 'oidc' and 'token' cannot be provided at the same time.",
-      );
-    }
+      if (this._data.oidc && coverageToken) {
+        errors.push(
+          "Both 'oidc' and 'token' cannot be provided at the same time.",
+        );
+      }
 
-    if (coverageToken && !COVERAGE_TOKEN_REGEX.test(coverageToken)) {
-      errors.push(
-        "The provided token is invalid. It should begin with 'qltcp_' or 'qltcw_' followed by alphanumerics.",
-      );
+      if (coverageToken && !COVERAGE_TOKEN_REGEX.test(coverageToken)) {
+        errors.push(
+          "The provided token is invalid. It should begin with 'qltcp_' or 'qltcw_' followed by alphanumerics.",
+        );
+      }
     }
 
     return errors;
   }
 
-  async getToken(): Promise<string> {
+  async getToken(): Promise<string | null> {
+    // For dry runs, we can return null when no authentication is provided
+    if (this._data.dryRun) {
+      if (this._data.oidc) {
+        return await this._input.getIDToken(OIDC_AUDIENCE);
+      } else {
+        const coverageToken = this.getCoverageToken();
+        return coverageToken || null;
+      }
+    }
+
     if (this._data.oidc) {
       return await this._input.getIDToken(OIDC_AUDIENCE);
     } else {

--- a/coverage/tests/action.test.ts
+++ b/coverage/tests/action.test.ts
@@ -197,6 +197,27 @@ describe("CoverageAction", () => {
     expect(command?.command).toContain("custom-name");
   });
 
+  test("allows dry-run without token or OIDC", async () => {
+    const { action, commands, output } = createTrackedAction({
+      settings: Settings.createNull({
+        token: "",
+        "coverage-token": "",
+        oidc: false,
+        files: "info.lcov",
+        "dry-run": true,
+      }),
+      context: { payload: {} },
+    });
+    await action.run();
+
+    const executedCommands = commands.clear();
+    expect(executedCommands.length).toBe(1);
+    const command = executedCommands[0];
+    expect(command?.command).toContain("--dry-run");
+    expect(command?.env?.["QLTY_COVERAGE_TOKEN"]).toBeUndefined();
+    expect(output.warnings.length).toBe(0); // No warnings should be generated
+  });
+
   describe("error handling", () => {
     test("throws an error if qlty fails when skip-errors is false", async () => {
       const { action } = createTrackedAction({

--- a/coverage/tests/settings.test.ts
+++ b/coverage/tests/settings.test.ts
@@ -162,6 +162,36 @@ describe("Settings", () => {
         }).validate(),
       ).toEqual([]);
     });
+
+    test("allows missing token and OIDC when dry-run is true", () => {
+      const settings = Settings.createNull({
+        token: "",
+        oidc: false,
+        "dry-run": true,
+      });
+
+      expect(settings.validate()).toEqual([]);
+    });
+
+    test("allows invalid token format when dry-run is true", () => {
+      const settings = Settings.createNull({
+        token: "invalid-token",
+        oidc: false,
+        "dry-run": true,
+      });
+
+      expect(settings.validate()).toEqual([]);
+    });
+
+    test("allows both token and OIDC when dry-run is true", () => {
+      const settings = Settings.createNull({
+        token: "qltcp_1234567890",
+        oidc: true,
+        "dry-run": true,
+      });
+
+      expect(settings.validate()).toEqual([]);
+    });
   });
 
   describe("getFiles", () => {
@@ -227,6 +257,40 @@ describe("Settings", () => {
 
       await expect(settings.getToken()).rejects.toThrow(
         "'token' is required when 'oidc' is false.",
+      );
+    });
+
+    test("returns null when in dry-run mode with no token", async () => {
+      const settings = Settings.createNull({
+        "coverage-token": "",
+        token: "",
+        oidc: false,
+        "dry-run": true,
+      });
+
+      expect(await settings.getToken()).toBeNull();
+    });
+
+    test("returns the token when in dry-run mode with a token", async () => {
+      const settings = Settings.createNull({
+        token: "qltcp_1234567890",
+        oidc: false,
+        "dry-run": true,
+      });
+
+      expect(await settings.getToken()).toEqual("qltcp_1234567890");
+    });
+
+    test("returns an ID token when in dry-run mode with oidc enabled", async () => {
+      const settings = Settings.createNull({
+        "coverage-token": "",
+        token: "",
+        oidc: true,
+        "dry-run": true,
+      });
+
+      expect(await settings.getToken()).toEqual(
+        "oidc-token:audience=https://qlty.sh",
       );
     });
   });


### PR DESCRIPTION
## Summary
- Allow running with dry-run option without providing authentication
- Skip token validation when dry-run is true
- Allow CLI execution without a token when in dry-run mode

## Test plan
- Added unit tests for validation logic with dry-run
- Added tests for token retrieval with dry-run
- Added integration test for action execution with dry-run without auth

🤖 Generated with [Claude Code](https://claude.ai/code)