### PR TITLE
Add validate input option to coverage action

### DIFF
--- a/coverage/README.md
+++ b/coverage/README.md
@@ -91,6 +91,7 @@ The Qlty Cloud offers free plans, including for commercial projects, with no lim
 | `dry-run`            | Run in dry run mode without uploading coverage data                                                                                                                                                                    | No       | `false` |
 | `incomplete`         | Mark the coverage data as incomplete                                                                                                                                                                                   | No       | `false` |
 | `name`               | Name to identify this coverage upload                                                                                                                                                                                  | No       | -       |
+| `validate`           | Validate coverage files before uploading                                                                                                                                                               | No       | `false` |
 
 ---
 

--- a/coverage/README.md
+++ b/coverage/README.md
@@ -92,6 +92,7 @@ The Qlty Cloud offers free plans, including for commercial projects, with no lim
 | `incomplete`         | Mark the coverage data as incomplete                                                                                                                                                                                   | No       | `false` |
 | `name`               | Name to identify this coverage upload                                                                                                                                                                                  | No       | -       |
 | `validate`           | Validate coverage files before uploading                                                                                                                                                               | No       | `false` |
+| `validate-file-threshold` | Custom threshold percentage for file validation (0-100, default is 90). Only applies when validate is true.                                                                                        | No       | -       |
 
 ---
 

--- a/coverage/action.yml
+++ b/coverage/action.yml
@@ -103,6 +103,11 @@ inputs:
     required: false
     default: false
 
+  validate-file-threshold:
+    description: "Custom threshold percentage for file validation (0-100, default is 90). Only applies when validate is true."
+    required: false
+    default: ""
+
 runs:
   using: node20
   main: dist/index.js

--- a/coverage/action.yml
+++ b/coverage/action.yml
@@ -98,6 +98,11 @@ inputs:
     required: false
     default: ""
 
+  validate:
+    description: "Validate coverage files before uploading"
+    required: false
+    default: false
+
 runs:
   using: node20
   main: dist/index.js

--- a/coverage/dist/index.js
+++ b/coverage/dist/index.js
@@ -73599,7 +73599,8 @@ var settingsParser = z.object({
   format: z.union([formatEnum, z.literal("")]).transform((val) => val === "" ? void 0 : val).optional(),
   dryRun: z.boolean(),
   incomplete: z.boolean(),
-  name: optionalNormalizedString
+  name: optionalNormalizedString,
+  validate: z.boolean()
 });
 var OIDC_AUDIENCE = "https://qlty.sh";
 var COVERAGE_TOKEN_REGEX = /^(qltcp_|qltcw_)[a-zA-Z0-9]{10,}$/;
@@ -73630,7 +73631,8 @@ var Settings = class _Settings {
         format: input.getInput("format"),
         dryRun: input.getBooleanInput("dry-run"),
         incomplete: input.getBooleanInput("incomplete"),
-        name: input.getInput("name")
+        name: input.getInput("name"),
+        validate: input.getBooleanInput("validate")
       }),
       input,
       fs
@@ -73750,7 +73752,8 @@ var StubbedInputProvider = class {
       format: data["format"] || "",
       "dry-run": data["dry-run"] || false,
       incomplete: data.incomplete || false,
-      name: data.name || ""
+      name: data.name || "",
+      validate: data.validate || false
     };
   }
   getInput(name, _options) {
@@ -73985,6 +73988,9 @@ var CoverageAction = class _CoverageAction {
     }
     if (this._settings.input.name) {
       uploadArgs.push("--name", this._settings.input.name);
+    }
+    if (this._settings.input.validate) {
+      uploadArgs.push("--validate");
     }
     return uploadArgs;
   }

--- a/coverage/dist/index.js
+++ b/coverage/dist/index.js
@@ -73600,7 +73600,13 @@ var settingsParser = z.object({
   dryRun: z.boolean(),
   incomplete: z.boolean(),
   name: optionalNormalizedString,
-  validate: z.boolean()
+  validate: z.boolean(),
+  validateFileThreshold: z.string().transform((val) => {
+    if (val === "") return void 0;
+    const num = Number(val);
+    if (isNaN(num) || num < 0 || num > 100) return void 0;
+    return num;
+  })
 });
 var OIDC_AUDIENCE = "https://qlty.sh";
 var COVERAGE_TOKEN_REGEX = /^(qltcp_|qltcw_)[a-zA-Z0-9]{10,}$/;
@@ -73632,7 +73638,8 @@ var Settings = class _Settings {
         dryRun: input.getBooleanInput("dry-run"),
         incomplete: input.getBooleanInput("incomplete"),
         name: input.getInput("name"),
-        validate: input.getBooleanInput("validate")
+        validate: input.getBooleanInput("validate"),
+        validateFileThreshold: input.getInput("validate-file-threshold")
       }),
       input,
       fs
@@ -73753,7 +73760,8 @@ var StubbedInputProvider = class {
       "dry-run": data["dry-run"] || false,
       incomplete: data.incomplete || false,
       name: data.name || "",
-      validate: data.validate || false
+      validate: data.validate || false,
+      "validate-file-threshold": data["validate-file-threshold"] || ""
     };
   }
   getInput(name, _options) {
@@ -73991,6 +73999,9 @@ var CoverageAction = class _CoverageAction {
     }
     if (this._settings.input.validate) {
       uploadArgs.push("--validate");
+      if (this._settings.input.validateFileThreshold !== void 0) {
+        uploadArgs.push("--validate-file-threshold", this._settings.input.validateFileThreshold.toString());
+      }
     }
     return uploadArgs;
   }

--- a/coverage/src/action.ts
+++ b/coverage/src/action.ts
@@ -236,6 +236,10 @@ export class CoverageAction {
 
     if (this._settings.input.validate) {
       uploadArgs.push("--validate");
+      
+      if (this._settings.input.validateFileThreshold !== undefined) {
+        uploadArgs.push("--validate-file-threshold", this._settings.input.validateFileThreshold.toString());
+      }
     }
 
     return uploadArgs;

--- a/coverage/src/action.ts
+++ b/coverage/src/action.ts
@@ -234,6 +234,10 @@ export class CoverageAction {
       uploadArgs.push("--name", this._settings.input.name);
     }
 
+    if (this._settings.input.validate) {
+      uploadArgs.push("--validate");
+    }
+
     return uploadArgs;
   }
 

--- a/coverage/src/settings.ts
+++ b/coverage/src/settings.ts
@@ -29,6 +29,7 @@ interface ActionInputKeys {
   "dry-run": boolean;
   incomplete: boolean;
   name: string;
+  validate: boolean;
 }
 
 const optionalNormalizedString = z
@@ -71,6 +72,7 @@ const settingsParser = z.object({
   dryRun: z.boolean(),
   incomplete: z.boolean(),
   name: optionalNormalizedString,
+  validate: z.boolean(),
 });
 
 export type SettingsOutput = z.output<typeof settingsParser>;
@@ -105,6 +107,7 @@ export class Settings {
         dryRun: input.getBooleanInput("dry-run"),
         incomplete: input.getBooleanInput("incomplete"),
         name: input.getInput("name"),
+        validate: input.getBooleanInput("validate"),
       }),
       input,
       fs,
@@ -270,6 +273,7 @@ export class StubbedInputProvider implements InputProvider {
       "dry-run": data["dry-run"] || false,
       incomplete: data.incomplete || false,
       name: data.name || "",
+      validate: data.validate || false,
     };
   }
 

--- a/coverage/src/settings.ts
+++ b/coverage/src/settings.ts
@@ -30,6 +30,7 @@ interface ActionInputKeys {
   incomplete: boolean;
   name: string;
   validate: boolean;
+  "validate-file-threshold": string;
 }
 
 const optionalNormalizedString = z
@@ -73,6 +74,12 @@ const settingsParser = z.object({
   incomplete: z.boolean(),
   name: optionalNormalizedString,
   validate: z.boolean(),
+  validateFileThreshold: z.string().transform((val) => {
+    if (val === "") return undefined;
+    const num = Number(val);
+    if (isNaN(num) || num < 0 || num > 100) return undefined;
+    return num;
+  }),
 });
 
 export type SettingsOutput = z.output<typeof settingsParser>;
@@ -108,6 +115,7 @@ export class Settings {
         incomplete: input.getBooleanInput("incomplete"),
         name: input.getInput("name"),
         validate: input.getBooleanInput("validate"),
+        validateFileThreshold: input.getInput("validate-file-threshold"),
       }),
       input,
       fs,
@@ -274,6 +282,7 @@ export class StubbedInputProvider implements InputProvider {
       incomplete: data.incomplete || false,
       name: data.name || "",
       validate: data.validate || false,
+      "validate-file-threshold": data["validate-file-threshold"] || "",
     };
   }
 

--- a/coverage/tests/action.test.ts
+++ b/coverage/tests/action.test.ts
@@ -197,6 +197,23 @@ describe("CoverageAction", () => {
     expect(command?.command).toContain("custom-name");
   });
 
+  test("adds validate flag when validate is true", async () => {
+    const { action, commands } = createTrackedAction({
+      settings: Settings.createNull({
+        "coverage-token": "qltcp_1234567890",
+        files: "info.lcov",
+        validate: true,
+      }),
+      context: { payload: {} },
+    });
+    await action.run();
+
+    const executedCommands = commands.clear();
+    expect(executedCommands.length).toBe(1);
+    const command = executedCommands[0];
+    expect(command?.command).toContain("--validate");
+  });
+
   test("allows dry-run without token or OIDC", async () => {
     const { action, commands, output } = createTrackedAction({
       settings: Settings.createNull({

--- a/coverage/tests/action.test.ts
+++ b/coverage/tests/action.test.ts
@@ -214,6 +214,45 @@ describe("CoverageAction", () => {
     expect(command?.command).toContain("--validate");
   });
 
+  test("adds validate-file-threshold flag when validate is true and threshold is provided", async () => {
+    const { action, commands } = createTrackedAction({
+      settings: Settings.createNull({
+        "coverage-token": "qltcp_1234567890",
+        files: "info.lcov",
+        validate: true,
+        "validate-file-threshold": "85",
+      }),
+      context: { payload: {} },
+    });
+    await action.run();
+
+    const executedCommands = commands.clear();
+    expect(executedCommands.length).toBe(1);
+    const command = executedCommands[0];
+    expect(command?.command).toContain("--validate");
+    expect(command?.command).toContain("--validate-file-threshold");
+    expect(command?.command).toContain("85");
+  });
+
+  test("does not add validate-file-threshold flag when validate is false", async () => {
+    const { action, commands } = createTrackedAction({
+      settings: Settings.createNull({
+        "coverage-token": "qltcp_1234567890",
+        files: "info.lcov",
+        validate: false,
+        "validate-file-threshold": "85",
+      }),
+      context: { payload: {} },
+    });
+    await action.run();
+
+    const executedCommands = commands.clear();
+    expect(executedCommands.length).toBe(1);
+    const command = executedCommands[0];
+    expect(command?.command).not.toContain("--validate");
+    expect(command?.command).not.toContain("--validate-file-threshold");
+  });
+
   test("allows dry-run without token or OIDC", async () => {
     const { action, commands, output } = createTrackedAction({
       settings: Settings.createNull({

--- a/coverage/tests/settings.test.ts
+++ b/coverage/tests/settings.test.ts
@@ -19,6 +19,7 @@ describe("Settings", () => {
       incomplete: true,
       name: "test-name",
       validate: true,
+      "validate-file-threshold": "95",
     });
 
     expect(settings.input).toMatchObject({
@@ -38,6 +39,7 @@ describe("Settings", () => {
       incomplete: true,
       name: "test-name",
       validate: true,
+      validateFileThreshold: 95,
     });
   });
 
@@ -65,6 +67,7 @@ describe("Settings", () => {
       incomplete: false,
       name: undefined,
       validate: false,
+      validateFileThreshold: undefined,
     });
   });
 
@@ -318,6 +321,41 @@ describe("Settings", () => {
         "cli-version": "v1.2.3",
       });
       expect(settings.getVersion()).toEqual("1.2.3");
+    });
+  });
+
+  describe("validateFileThreshold", () => {
+    test("handles valid threshold", () => {
+      const settings = Settings.createNull({
+        "validate-file-threshold": "75",
+      });
+      expect(settings.input.validateFileThreshold).toEqual(75);
+    });
+
+    test("handles empty threshold", () => {
+      const settings = Settings.createNull({
+        "validate-file-threshold": "",
+      });
+      expect(settings.input.validateFileThreshold).toBeUndefined();
+    });
+
+    test("rejects out of range threshold", () => {
+      const settings = Settings.createNull({
+        "validate-file-threshold": "101",
+      });
+      expect(settings.input.validateFileThreshold).toBeUndefined();
+
+      const settings2 = Settings.createNull({
+        "validate-file-threshold": "-1",
+      });
+      expect(settings2.input.validateFileThreshold).toBeUndefined();
+    });
+
+    test("rejects non-numeric threshold", () => {
+      const settings = Settings.createNull({
+        "validate-file-threshold": "abc",
+      });
+      expect(settings.input.validateFileThreshold).toBeUndefined();
     });
   });
 });

--- a/coverage/tests/settings.test.ts
+++ b/coverage/tests/settings.test.ts
@@ -18,6 +18,7 @@ describe("Settings", () => {
       "dry-run": true,
       incomplete: true,
       name: "test-name",
+      validate: true,
     });
 
     expect(settings.input).toMatchObject({
@@ -36,6 +37,7 @@ describe("Settings", () => {
       dryRun: true,
       incomplete: true,
       name: "test-name",
+      validate: true,
     });
   });
 
@@ -62,6 +64,7 @@ describe("Settings", () => {
       dryRun: false,
       incomplete: false,
       name: undefined,
+      validate: false,
     });
   });
 


### PR DESCRIPTION
## Summary
- Add a new `validate` input option (defaults to false) to the coverage action
- When enabled, adds the `--validate` flag to the `qlty coverage publish` command
- Add test coverage and documentation for the new option

## Test plan
- Verified tests pass with `npm run test`
- Verified build works with `npm run all`
- Manually tested by adding `validate: true` to the action inputs and confirming the `--validate` flag is added to the command

🤖 Generated with [Claude Code](https://claude.ai/code)