### PR TITLE
Change 'files' parameter to only be required when command is `publish`

### DIFF
--- a/coverage/src/action.ts
+++ b/coverage/src/action.ts
@@ -95,7 +95,7 @@ export class CoverageAction {
     const files = await this._settings.getFiles();
 
     if (files.length === 0) {
-      if (this._settings.input.files.includes(" ")) {
+      if (this._settings.input.files?.includes(" ")) {
         this.warnOrThrow([
           "No code coverage data files were found. Please check the action's inputs.",
           "NOTE: To specify multiple files, use a comma or newline separated list NOT spaces.",

--- a/coverage/src/settings.ts
+++ b/coverage/src/settings.ts
@@ -58,7 +58,7 @@ const formatEnum = z.enum([
 const settingsParser = z.object({
   token: preprocessBlanks(z.string().optional()),
   coverageToken: preprocessBlanks(z.string().optional()),
-  files: z.string().trim(),
+  files: preprocessBlanks(z.string().trim().optional()),
   addPrefix: preprocessBlanks(z.string().optional()),
   stripPrefix: preprocessBlanks(z.string().optional()),
   skipErrors: z.boolean(),
@@ -95,7 +95,7 @@ export class Settings {
   ): Settings {
     return new Settings(
       settingsParser.parse({
-        files: input.getInput("files", { required: true }).trim(),
+        files: input.getInput("files"),
         addPrefix: input.getInput("add-prefix"),
         stripPrefix: input.getInput("strip-prefix"),
         skipErrors: input.getBooleanInput("skip-errors"),
@@ -156,6 +156,10 @@ export class Settings {
       }
     }
 
+    if(this._data.command === "publish" && !this._data.files) {
+      errors.push("The 'files' input is required when command is 'publish'.");
+    }
+
     // Check if validate-file-threshold is provided without enabling validate
     if (
       this._data.validateFileThreshold !== undefined &&
@@ -169,7 +173,7 @@ export class Settings {
     // Validate that specific inputs are not used when command is "complete"
     if (this._data.command === "complete") {
       const invalidInputsForComplete = [
-        { name: "files", value: this._data.files !== "" },
+        { name: "files", value: this._data.files !== undefined },
         { name: "add-prefix", value: this._data.addPrefix !== undefined },
         { name: "strip-prefix", value: this._data.stripPrefix !== undefined },
         { name: "dry-run", value: this._data.dryRun },

--- a/coverage/src/settings.ts
+++ b/coverage/src/settings.ts
@@ -34,7 +34,7 @@ interface ActionInputKeys {
   command: string;
 }
 
-function preprocessBlanks(zType: ZodType): ZodType {
+function preprocessBlanks<T extends ZodType>(zType: T) {
   return z.preprocess((val) => {
     if (val === "" || val === null) {
       return undefined;
@@ -58,7 +58,7 @@ const formatEnum = z.enum([
 const settingsParser = z.object({
   token: preprocessBlanks(z.string().optional()),
   coverageToken: preprocessBlanks(z.string().optional()),
-  files: preprocessBlanks(z.string().trim().optional()),
+  files: preprocessBlanks(z.string().optional()),
   addPrefix: preprocessBlanks(z.string().optional()),
   stripPrefix: preprocessBlanks(z.string().optional()),
   skipErrors: z.boolean(),
@@ -241,6 +241,9 @@ export class Settings {
   }
 
   async getFiles() {
+    if (!this._data.files) {
+      return [];
+    }
     const patterns: string[] = this._data.files
       .split(",")
       .map((file) => file.trim())

--- a/coverage/src/settings.ts
+++ b/coverage/src/settings.ts
@@ -58,7 +58,7 @@ const formatEnum = z.enum([
 const settingsParser = z.object({
   token: preprocessBlanks(z.string().optional()),
   coverageToken: preprocessBlanks(z.string().optional()),
-  files: preprocessBlanks(z.string().optional()),
+  files: preprocessBlanks(z.string().trim().optional()),
   addPrefix: preprocessBlanks(z.string().optional()),
   stripPrefix: preprocessBlanks(z.string().optional()),
   skipErrors: z.boolean(),

--- a/coverage/src/settings.ts
+++ b/coverage/src/settings.ts
@@ -156,7 +156,7 @@ export class Settings {
       }
     }
 
-    if(this._data.command === "publish" && !this._data.files) {
+    if (this._data.command === "publish" && !this._data.files) {
       errors.push("The 'files' input is required when command is 'publish'.");
     }
 

--- a/coverage/tests/action.test.ts
+++ b/coverage/tests/action.test.ts
@@ -1,6 +1,6 @@
 import { CoverageAction, StubbedActionContext } from "src/action";
 import { Installer } from "src/installer";
-import { Settings, StubbedFileSystem } from "src/settings";
+import { FileSystem, Settings, StubbedFileSystem } from "src/settings";
 import { StubbedCommandExecutor } from "src/util/exec";
 import { StubbedOutput } from "src/util/output";
 
@@ -48,9 +48,11 @@ describe("CoverageAction", () => {
         executor: new StubbedCommandExecutor({ throwError: true }),
         settings: Settings.createNull({
           oidc: true,
-          files: "",
+          files: "some/non-existent/file",
           "skip-errors": true,
-        }),
+        },
+        FileSystem.createNull([]) // returns no files
+      ),
       });
 
       await action.run();

--- a/coverage/tests/action.test.ts
+++ b/coverage/tests/action.test.ts
@@ -46,13 +46,14 @@ describe("CoverageAction", () => {
     test("logs warnings no paths found", async () => {
       const { output, action } = createTrackedAction({
         executor: new StubbedCommandExecutor({ throwError: true }),
-        settings: Settings.createNull({
-          oidc: true,
-          files: "some/non-existent/file",
-          "skip-errors": true,
-        },
-        FileSystem.createNull([]) // returns no files
-      ),
+        settings: Settings.createNull(
+          {
+            oidc: true,
+            files: "some/non-existent/file",
+            "skip-errors": true,
+          },
+          FileSystem.createNull([]), // returns no files
+        ),
       });
 
       await action.run();

--- a/coverage/tests/settings.test.ts
+++ b/coverage/tests/settings.test.ts
@@ -271,6 +271,7 @@ describe("Settings", () => {
         Settings.createNull({
           "coverage-token": "qltcp_1234567890",
           oidc: false,
+          files: "coverage.json",
         }).validate(),
       ).toEqual([]);
 
@@ -278,6 +279,7 @@ describe("Settings", () => {
         Settings.createNull({
           token: "qltcp_1234567890",
           oidc: false,
+          files: "coverage.json",
         }).validate(),
       ).toEqual([]);
 
@@ -286,6 +288,7 @@ describe("Settings", () => {
           "coverage-token": "",
           token: "",
           oidc: true,
+          files: "coverage.json",
         }).validate(),
       ).toEqual([]);
 
@@ -296,14 +299,27 @@ describe("Settings", () => {
           oidc: false,
           validate: true,
           "validate-file-threshold": "80",
+          files: "coverage.json",
         }).validate(),
       ).toEqual([]);
+    });
+
+    test("fails when files is missing", () => {
+      const settings = Settings.createNull({
+        token: "qltcp_1234567890",
+        oidc: false,
+        files: "",
+      });
+      expect(settings.validate()).toEqual([
+        "The 'files' input is required when command is 'publish'.",
+      ]);
     });
 
     test("fails when OIDC and token are both missing", () => {
       const settings = Settings.createNull({
         token: "",
         oidc: false,
+        files: "coverage.json",
       });
 
       expect(settings.validate()).toEqual([
@@ -315,6 +331,7 @@ describe("Settings", () => {
       const settings = Settings.createNull({
         token: "qltcp_1234567890",
         oidc: true,
+        files: "coverage.json",
       });
 
       expect(settings.validate()).toEqual([
@@ -326,6 +343,7 @@ describe("Settings", () => {
       expect(
         Settings.createNull({
           token: "wrong",
+          files: "coverage.json",
         }).validate(),
       ).toEqual([
         "The provided token is invalid. It should begin with 'qltcp_' or 'qltcw_' followed by alphanumerics.",
@@ -334,6 +352,7 @@ describe("Settings", () => {
       expect(
         Settings.createNull({
           "coverage-token": "wrong",
+          files: "coverage.json",
         }).validate(),
       ).toEqual([
         "The provided token is invalid. It should begin with 'qltcp_' or 'qltcw_' followed by alphanumerics.",
@@ -342,6 +361,7 @@ describe("Settings", () => {
       expect(
         Settings.createNull({
           "coverage-token": "qltcp_1234567890",
+          files: "coverage.json",
         }).validate(),
       ).toEqual([]);
     });
@@ -351,6 +371,7 @@ describe("Settings", () => {
         token: "",
         oidc: false,
         "dry-run": true,
+        files: "coverage.json",
       });
 
       expect(settings.validate()).toEqual([]);
@@ -361,6 +382,7 @@ describe("Settings", () => {
         token: "invalid-token",
         oidc: false,
         "dry-run": true,
+        files: "coverage.json",
       });
 
       expect(settings.validate()).toEqual([]);
@@ -371,6 +393,7 @@ describe("Settings", () => {
         token: "qltcp_1234567890",
         oidc: true,
         "dry-run": true,
+        files: "coverage.json",
       });
 
       expect(settings.validate()).toEqual([]);
@@ -382,6 +405,7 @@ describe("Settings", () => {
         oidc: false,
         validate: false,
         "validate-file-threshold": "80",
+        files: "coverage.json",
       });
 
       expect(settings.validate()).toEqual([


### PR DESCRIPTION
Previously we only supported a single command (publish) which requires a files parameter. We now support 2 commands: publish and complete. "files" is an invalid parameter when the command is complete.

This makes 'files' an optional action parameter which then requires our code to provide its own validation of the files parameter based on the command.