### PR TITLE
fix: set output directory to RUNNER_TEMP

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,6 +99,14 @@ jobs:
           oidc: true
           files: coverage/coverage/clover.xml
 
+      - name: Verify clean working directory
+        run: |
+          if [ "$(git status --porcelain)" ]; then
+            echo "Working directory is not clean. Please commit or stash your changes."
+            git status
+            exit 1
+          fi
+
   test-windows-coverage:
     runs-on: windows-latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 - Add support for Windows to coverage action (#87)
 - Set `QLTY_CI_UPLOADER_TOOL` and `QLTY_CI_UPLOADER_VERSION` when running CLI (#86)
 - Allow dry-run without authentication (#91)
+- Write coverage archive to RUNNER_TEMP location when available (#110)
+
+Thank you, @enell for your contribution!
 
 ## v1.0.0 (2025-04-17)
 

--- a/coverage/dist/index.js
+++ b/coverage/dist/index.js
@@ -74097,6 +74097,9 @@ var CoverageAction = class _CoverageAction {
         );
       }
     }
+    if (process.env["RUNNER_TEMP"]) {
+      uploadArgs.push("--output-dir", process.env["RUNNER_TEMP"]);
+    }
     return uploadArgs;
   }
   trackOutput() {

--- a/coverage/dist/index.js
+++ b/coverage/dist/index.js
@@ -73872,7 +73872,8 @@ var CoverageAction = class _CoverageAction {
     context: context3 = actionsGithub.context,
     executor = actionsExec,
     installer,
-    settings = Settings.create()
+    settings = Settings.create(),
+    env = process.env
   } = {}) {
     __publicField(this, "_output");
     __publicField(this, "_context");
@@ -73880,25 +73881,29 @@ var CoverageAction = class _CoverageAction {
     __publicField(this, "_installer");
     __publicField(this, "_settings");
     __publicField(this, "_emitter", new import_node_events2.default());
+    __publicField(this, "_env");
     this._output = output;
     this._context = context3;
     this._executor = executor;
     this._installer = installer || Installer.create(settings.getVersion());
     this._settings = settings;
+    this._env = env;
   }
   static createNull({
     output = new StubbedOutput(),
     context: context3 = new StubbedActionContext(),
     executor = new StubbedCommandExecutor(),
     installer,
-    settings = Settings.createNull()
+    settings = Settings.createNull(),
+    env = process.env
   } = {}) {
     return new _CoverageAction({
       output,
       context: context3,
       executor,
       installer: installer || Installer.createNull(settings.getVersion()),
-      settings
+      settings,
+      env
     });
   }
   async run() {
@@ -73952,7 +73957,7 @@ var CoverageAction = class _CoverageAction {
     let qlytOutput = "";
     try {
       const env = {
-        ...process.env,
+        ...this._env,
         QLTY_CI_UPLOADER_TOOL: "qltysh/qlty-action",
         QLTY_CI_UPLOADER_VERSION: Version.readVersion() || ""
       };
@@ -73994,7 +73999,7 @@ var CoverageAction = class _CoverageAction {
     let qlytOutput = "";
     try {
       const env = {
-        ...process.env,
+        ...this._env,
         QLTY_CI_UPLOADER_TOOL: "qltysh/qlty-action",
         QLTY_CI_UPLOADER_VERSION: Version.readVersion() || ""
       };
@@ -74097,8 +74102,8 @@ var CoverageAction = class _CoverageAction {
         );
       }
     }
-    if (process.env["RUNNER_TEMP"]) {
-      uploadArgs.push("--output-dir", process.env["RUNNER_TEMP"]);
+    if (this._env["RUNNER_TEMP"]) {
+      uploadArgs.push("--output-dir", this._env["RUNNER_TEMP"]);
     }
     return uploadArgs;
   }

--- a/coverage/src/action.ts
+++ b/coverage/src/action.ts
@@ -303,6 +303,10 @@ export class CoverageAction {
       }
     }
 
+    if (process.env["RUNNER_TEMP"]) {
+      uploadArgs.push("--output-dir", process.env["RUNNER_TEMP"]);
+    }
+
     return uploadArgs;
   }
 

--- a/coverage/src/action.ts
+++ b/coverage/src/action.ts
@@ -12,6 +12,8 @@ import Version from "./version";
 
 const EXEC_EVENT = "exec";
 
+type ProcessEnv = Record<string, string | undefined>;
+
 export class CoverageAction {
   private _output: ActionOutput;
   private _context: ActionContext;
@@ -19,6 +21,7 @@ export class CoverageAction {
   private _installer: Installer;
   private _settings: Settings;
   private _emitter: EventEmitter = new EventEmitter();
+  private _env: ProcessEnv;
 
   static createNull({
     output = new StubbedOutput(),
@@ -26,12 +29,14 @@ export class CoverageAction {
     executor = new StubbedCommandExecutor(),
     installer,
     settings = Settings.createNull(),
+    env = process.env,
   }: {
     output?: ActionOutput;
     context?: ActionContext;
     executor?: CommandExecutor;
     installer?: Installer;
     settings?: Settings;
+    env?: ProcessEnv;
   } = {}): CoverageAction {
     return new CoverageAction({
       output,
@@ -39,6 +44,7 @@ export class CoverageAction {
       executor,
       installer: installer || Installer.createNull(settings.getVersion()),
       settings,
+      env,
     });
   }
 
@@ -48,18 +54,21 @@ export class CoverageAction {
     executor = actionsExec,
     installer,
     settings = Settings.create(),
+    env = process.env,
   }: {
     output?: ActionOutput;
     context?: ActionContext;
     executor?: CommandExecutor;
     installer?: Installer;
     settings?: Settings;
+    env?: ProcessEnv;
   } = {}) {
     this._output = output;
     this._context = context;
     this._executor = executor;
     this._installer = installer || Installer.create(settings.getVersion());
     this._settings = settings;
+    this._env = env;
   }
 
   async run(): Promise<void> {
@@ -124,7 +133,7 @@ export class CoverageAction {
 
     try {
       const env: Record<string, string> = {
-        ...process.env,
+        ...this._env,
         QLTY_CI_UPLOADER_TOOL: "qltysh/qlty-action",
         QLTY_CI_UPLOADER_VERSION: Version.readVersion() || "",
       };
@@ -174,7 +183,7 @@ export class CoverageAction {
 
     try {
       const env: Record<string, string> = {
-        ...process.env,
+        ...this._env,
         QLTY_CI_UPLOADER_TOOL: "qltysh/qlty-action",
         QLTY_CI_UPLOADER_VERSION: Version.readVersion() || "",
       };
@@ -303,8 +312,8 @@ export class CoverageAction {
       }
     }
 
-    if (process.env["RUNNER_TEMP"]) {
-      uploadArgs.push("--output-dir", process.env["RUNNER_TEMP"]);
+    if (this._env["RUNNER_TEMP"]) {
+      uploadArgs.push("--output-dir", this._env["RUNNER_TEMP"]);
     }
 
     return uploadArgs;

--- a/coverage/tests/action.test.ts
+++ b/coverage/tests/action.test.ts
@@ -52,7 +52,7 @@ describe("CoverageAction", () => {
             files: "some/non-existent/file",
             "skip-errors": true,
           },
-          FileSystem.createNull([]), // returns no files
+          FileSystem.createNull([]) // returns no files
         ),
       });
 
@@ -138,7 +138,7 @@ describe("CoverageAction", () => {
         QLTY_CI_UPLOADER_TOOL: "qltysh/qlty-action",
       });
       expect(command?.env["QLTY_CI_UPLOADER_VERSION"]).toMatch(
-        /^\d+\.\d+\.\d+(-[0-9A-Za-z-.]+)?$/,
+        /^\d+\.\d+\.\d+(-[0-9A-Za-z-.]+)?$/
       );
     });
 
@@ -336,7 +336,7 @@ describe("CoverageAction", () => {
         QLTY_CI_UPLOADER_TOOL: "qltysh/qlty-action",
       });
       expect(command?.env["QLTY_CI_UPLOADER_VERSION"]).toMatch(
-        /^\d+\.\d+\.\d+(-[0-9A-Za-z-.]+)?$/,
+        /^\d+\.\d+\.\d+(-[0-9A-Za-z-.]+)?$/
       );
     });
 
@@ -354,7 +354,7 @@ describe("CoverageAction", () => {
       expect(executedCommands.length).toBe(1);
       const command = executedCommands[0];
       expect(command?.env["QLTY_COVERAGE_TOKEN"]).toBe(
-        "oidc-token:audience=https://qlty.sh",
+        "oidc-token:audience=https://qlty.sh"
       );
     });
 
@@ -444,7 +444,7 @@ describe("CoverageAction", () => {
             files: "file1.lcov file2.lcov",
             "skip-errors": true,
           },
-          new StubbedFileSystem([]),
+          new StubbedFileSystem([])
         ),
       });
 
@@ -464,7 +464,7 @@ describe("CoverageAction", () => {
     executor = new StubbedCommandExecutor(),
     output = new StubbedOutput(),
     installer = Installer.createNull(undefined),
-    env = process.env,
+    env = {},
   } = {}) {
     const action = CoverageAction.createNull({
       output,


### PR DESCRIPTION
When running without specifying output-dir a tmp folder is created in the workspace. To avoid making the workspace dirty set the output dir to [RUNNER_TEMP](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables) instead
