### PR TITLE
fix: more robust error output in face of unknown errors

### DIFF
--- a/coverage/src/action.ts
+++ b/coverage/src/action.ts
@@ -129,7 +129,7 @@ export class CoverageAction {
       this._output.setSecret(token);
     }
 
-    let qlytOutput = "";
+    let qltyOutput = "";
 
     try {
       const env: Record<string, string> = {
@@ -152,18 +152,15 @@ export class CoverageAction {
         env,
         listeners: {
           stdout: (data: Buffer) => {
-            qlytOutput += data.toString();
+            qltyOutput += data.toString();
           },
           stderr: (data: Buffer) => {
-            qlytOutput += data.toString();
+            qltyOutput += data.toString();
           },
         },
       });
-    } catch {
-      this.warnOrThrow([
-        "Error uploading coverage. Output from the Qlty CLI follows:",
-        qlytOutput,
-      ]);
+    } catch (error) {
+      this.outputCoverageError(qltyOutput, error);
     }
   }
 
@@ -179,7 +176,7 @@ export class CoverageAction {
       this._output.setSecret(token);
     }
 
-    let qlytOutput = "";
+    let qltyOutput = "";
 
     try {
       const env: Record<string, string> = {
@@ -202,17 +199,36 @@ export class CoverageAction {
         env,
         listeners: {
           stdout: (data: Buffer) => {
-            qlytOutput += data.toString();
+            qltyOutput += data.toString();
           },
           stderr: (data: Buffer) => {
-            qlytOutput += data.toString();
+            qltyOutput += data.toString();
           },
         },
       });
-    } catch {
+    } catch (error) {
+      this.outputCoverageError(qltyOutput, error);
+    }
+  }
+
+  outputCoverageError(qltyOutput: string, error: unknown): void {
+    if (qltyOutput) {
       this.warnOrThrow([
-        "Error completing coverage. Output from the Qlty CLI follows:",
-        qlytOutput,
+        `Error executing coverage command. Output from the Qlty CLI follows:`,
+        qltyOutput,
+      ]);
+    } else {
+      let errorMessage = "";
+
+      if (error instanceof Error) {
+        errorMessage = error.message;
+      } else if (typeof error === "string") {
+        errorMessage = error;
+      }
+
+      this.warnOrThrow([
+        `Unexpected error executing coverage command:`,
+        errorMessage,
       ]);
     }
   }

--- a/coverage/src/util/exec.ts
+++ b/coverage/src/util/exec.ts
@@ -10,9 +10,34 @@ export interface CommandExecutor {
 
 export class StubbedCommandExecutor implements CommandExecutor {
   private throwError: boolean;
+  private errorMessage: string = "Command execution failed";
+  private stdout: string = "STDOUT\n";
+  private stderr: string = "STDERR\n";
 
-  constructor({ throwError }: { throwError?: boolean } = {}) {
+  constructor({
+    throwError,
+    stdout,
+    stderr,
+    errorMessage,
+  }: {
+    throwError?: boolean;
+    stdout?: string;
+    stderr?: string;
+    errorMessage?: string;
+  } = {}) {
     this.throwError = !!throwError;
+
+    if (stdout !== undefined) {
+      this.stdout = stdout;
+    }
+
+    if (stderr !== undefined) {
+      this.stderr = stderr;
+    }
+
+    if (errorMessage !== undefined) {
+      this.errorMessage = errorMessage;
+    }
   }
 
   async exec(
@@ -22,14 +47,14 @@ export class StubbedCommandExecutor implements CommandExecutor {
   ): Promise<number> {
     if (this.throwError) {
       if (options?.listeners?.stdout) {
-        options.listeners.stdout(Buffer.from("STDOUT\n"));
+        options.listeners.stdout(Buffer.from(this.stdout));
       }
 
       if (options?.listeners?.stderr) {
-        options.listeners.stderr(Buffer.from("STDERR\n"));
+        options.listeners.stderr(Buffer.from(this.stderr));
       }
 
-      throw new Error("Command execution failed");
+      throw new Error(this.errorMessage);
     } else {
       return 0;
     }

--- a/coverage/tests/action.test.ts
+++ b/coverage/tests/action.test.ts
@@ -6,7 +6,7 @@ import { StubbedOutput } from "src/util/output";
 
 describe("CoverageAction", () => {
   describe("validation errors", async () => {
-    test("logs warnings shen skip-errors is true", async () => {
+    test("logs warnings when skip-errors is true", async () => {
       const { output, action } = createTrackedAction({
         executor: new StubbedCommandExecutor({ throwError: true }),
         settings: Settings.createNull({
@@ -27,7 +27,29 @@ describe("CoverageAction", () => {
       ]);
     });
 
-    test("raises errors shen skip-errors is false", async () => {
+    test("logs unknown error when output from execution is empty", async () => {
+      const { output, action } = createTrackedAction({
+        executor: new StubbedCommandExecutor({
+          throwError: true,
+          stdout: "",
+          stderr: "",
+          errorMessage: "Crazy unknown error condition happened",
+        }),
+        settings: Settings.createNull({
+          "coverage-token": "qltcp_1234567890",
+          files: "info.lcov",
+          "skip-errors": true,
+        }),
+      });
+
+      await action.run();
+      expect(output.warnings).toEqual([
+        "Unexpected error executing coverage command:",
+        "Crazy unknown error condition happened",
+      ]);
+    });
+
+    test("raises errors when skip-errors is false", async () => {
       const { action } = createTrackedAction({
         executor: new StubbedCommandExecutor({ throwError: true }),
         settings: Settings.createNull({
@@ -52,7 +74,7 @@ describe("CoverageAction", () => {
             files: "some/non-existent/file",
             "skip-errors": true,
           },
-          FileSystem.createNull([]) // returns no files
+          FileSystem.createNull([]), // returns no files
         ),
       });
 
@@ -138,7 +160,7 @@ describe("CoverageAction", () => {
         QLTY_CI_UPLOADER_TOOL: "qltysh/qlty-action",
       });
       expect(command?.env["QLTY_CI_UPLOADER_VERSION"]).toMatch(
-        /^\d+\.\d+\.\d+(-[0-9A-Za-z-.]+)?$/
+        /^\d+\.\d+\.\d+(-[0-9A-Za-z-.]+)?$/,
       );
     });
 
@@ -336,7 +358,7 @@ describe("CoverageAction", () => {
         QLTY_CI_UPLOADER_TOOL: "qltysh/qlty-action",
       });
       expect(command?.env["QLTY_CI_UPLOADER_VERSION"]).toMatch(
-        /^\d+\.\d+\.\d+(-[0-9A-Za-z-.]+)?$/
+        /^\d+\.\d+\.\d+(-[0-9A-Za-z-.]+)?$/,
       );
     });
 
@@ -354,7 +376,7 @@ describe("CoverageAction", () => {
       expect(executedCommands.length).toBe(1);
       const command = executedCommands[0];
       expect(command?.env["QLTY_COVERAGE_TOKEN"]).toBe(
-        "oidc-token:audience=https://qlty.sh"
+        "oidc-token:audience=https://qlty.sh",
       );
     });
 
@@ -383,7 +405,7 @@ describe("CoverageAction", () => {
 
       await action.run();
       expect(output.warnings).toEqual([
-        "Error completing coverage. Output from the Qlty CLI follows:",
+        "Error executing coverage command. Output from the Qlty CLI follows:",
         "STDOUT\nSTDERR\n",
       ]);
     });
@@ -415,7 +437,7 @@ describe("CoverageAction", () => {
 
       await action.run();
       expect(output.warnings).toEqual([
-        "Error uploading coverage. Output from the Qlty CLI follows:",
+        "Error executing coverage command. Output from the Qlty CLI follows:",
         "STDOUT\nSTDERR\n",
       ]);
     });
@@ -444,7 +466,7 @@ describe("CoverageAction", () => {
             files: "file1.lcov file2.lcov",
             "skip-errors": true,
           },
-          new StubbedFileSystem([])
+          new StubbedFileSystem([]),
         ),
       });
 


### PR DESCRIPTION
A customer recently reported an error running this action and the ouput of the action was simply:

```
Warning: Error uploading coverage. Output from the Qlty CLI follows:
```

This would happen, I believe, if an error occurs with the actual attempt to execute the qlty binary, as opposed to an error output by `qlty`.

We were not catching the `error` object in the try/catch blocks here, so effectively we're losing information when an error occurs.

This enhances our error reporting so that if an error occurs, and there's no output from the tool, we instead output information from the try/catch's error object.

I also fixed a couple cosmetic issues (typos in descriptions or variable names)