### PR TITLE
chore: Send --no-validate argument to CLI when validate is false

### DIFF
--- a/coverage/src/action.ts
+++ b/coverage/src/action.ts
@@ -328,6 +328,8 @@ export class CoverageAction {
           this._settings.input.validateFileThreshold.toString(),
         );
       }
+    } else {
+      uploadArgs.push("--no-validate");
     }
 
     if (this._env["RUNNER_TEMP"]) {

--- a/coverage/tests/action.test.ts
+++ b/coverage/tests/action.test.ts
@@ -105,6 +105,7 @@ describe("CoverageAction", () => {
         "qlty",
         "coverage",
         "publish",
+        "--no-validate",
         "info.lcov",
       ]);
     });
@@ -153,6 +154,7 @@ describe("CoverageAction", () => {
         "--incomplete",
         "--name",
         "test-name",
+        "--no-validate",
         "info.lcov",
       ]);
       expect(command?.env).toMatchObject({
@@ -184,6 +186,7 @@ describe("CoverageAction", () => {
         "test-sha",
         "--override-branch",
         "test-ref",
+        "--no-validate",
         "info.lcov",
       ]);
     });


### PR DESCRIPTION
Do not merge -- requires CLI to accept `--no-validate` option first.