### PR TITLE
fix: Ignore "validate" option when command is "complete"

### DIFF
--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -87,6 +87,7 @@ name = "yamllint"
 name = "eslint"
 package_file = ".qlty/configs/package.json"
 
-[[ignore]]
+[[exclude]]
 file_patterns = ["**/LICENSE.md"]
-rules = ["markdownlint:MD041"]
+plugins = ["markdownlint"]
+rules = ["MD041"]

--- a/coverage/dist/index.js
+++ b/coverage/dist/index.js
@@ -69357,6 +69357,7 @@ var StubbedOutput = class {
     __publicField(this, "paths", []);
     __publicField(this, "failures", []);
     __publicField(this, "infos", []);
+    __publicField(this, "errors", []);
     __publicField(this, "warnings", []);
   }
   addPath(path3) {
@@ -69373,6 +69374,9 @@ var StubbedOutput = class {
   }
   warning(message) {
     this.warnings.push(message);
+  }
+  error(message) {
+    this.errors.push(message);
   }
 };
 
@@ -73930,7 +73934,7 @@ var CoverageAction = class _CoverageAction {
       qltyBinary = await this._installer.install();
     } catch (error) {
       const errorMessage = error instanceof Error ? `: ${error.message}.` : ".";
-      this.warnOrThrow([
+      this.reportOrFail([
         `Error installing Qlty CLI${errorMessage} Please check the action's inputs. If you are using a 'cli-version', make sure it is correct.`
       ]);
       return;
@@ -73949,14 +73953,14 @@ var CoverageAction = class _CoverageAction {
     const files = await this._settings.getFiles();
     if (files.length === 0) {
       if (this._settings.input.files?.includes(" ")) {
-        this.warnOrThrow([
+        this.reportOrFail([
           "No code coverage data files were found. Please check the action's inputs.",
           "NOTE: To specify multiple files, use a comma or newline separated list NOT spaces.",
           "If you are using a pattern, make sure it is correct.",
           "If you are using a file, make sure it exists."
         ]);
       } else {
-        this.warnOrThrow([
+        this.reportOrFail([
           "No code coverage data files were found. Please check the action's inputs.",
           "If you are using a pattern, make sure it is correct.",
           "If you are using a file, make sure it exists."
@@ -74037,7 +74041,7 @@ var CoverageAction = class _CoverageAction {
   }
   outputCoverageError(qltyOutput, error) {
     if (qltyOutput) {
-      this.warnOrThrow([
+      this.reportOrFail([
         `Error executing coverage command. Output from the Qlty CLI follows:`,
         qltyOutput
       ]);
@@ -74048,7 +74052,7 @@ var CoverageAction = class _CoverageAction {
       } else if (typeof error === "string") {
         errorMessage = error;
       }
-      this.warnOrThrow([
+      this.reportOrFail([
         `Unexpected error executing coverage command:`,
         errorMessage
       ]);
@@ -74057,7 +74061,7 @@ var CoverageAction = class _CoverageAction {
   validate() {
     const errors = this._settings.validate();
     if (errors.length > 0) {
-      this.warnOrThrow([
+      this.reportOrFail([
         "Error validating action input:",
         ...errors,
         "Please check the action's inputs."
@@ -74066,10 +74070,10 @@ var CoverageAction = class _CoverageAction {
     }
     return true;
   }
-  warnOrThrow(messages) {
+  reportOrFail(messages) {
     if (this._settings.input.skipErrors) {
       for (const message of messages) {
-        this._output.warning(message);
+        this._output.error(message);
       }
     } else {
       throw new CoverageError(messages.join("; "));

--- a/coverage/dist/index.js
+++ b/coverage/dist/index.js
@@ -73681,7 +73681,6 @@ var Settings = class _Settings {
         { name: "files", value: this._data.files !== void 0 },
         { name: "add-prefix", value: this._data.addPrefix !== void 0 },
         { name: "strip-prefix", value: this._data.stripPrefix !== void 0 },
-        { name: "dry-run", value: this._data.dryRun },
         { name: "incomplete", value: this._data.incomplete },
         { name: "name", value: this._data.name !== void 0 },
         { name: "skip-missing-files", value: this._data.skipMissingFiles },

--- a/coverage/dist/index.js
+++ b/coverage/dist/index.js
@@ -73686,7 +73686,6 @@ var Settings = class _Settings {
         { name: "name", value: this._data.name !== void 0 },
         { name: "skip-missing-files", value: this._data.skipMissingFiles },
         { name: "format", value: this._data.format !== void 0 },
-        { name: "validate", value: this._data.validate },
         {
           name: "validate-file-threshold",
           value: this._data.validateFileThreshold !== void 0

--- a/coverage/src/action.ts
+++ b/coverage/src/action.ts
@@ -82,7 +82,7 @@ export class CoverageAction {
       qltyBinary = await this._installer.install();
     } catch (error) {
       const errorMessage = error instanceof Error ? `: ${error.message}.` : ".";
-      this.warnOrThrow([
+      this.reportOrFail([
         `Error installing Qlty CLI${errorMessage} Please check the action's inputs. If you are using a 'cli-version', make sure it is correct.`,
       ]);
       return;
@@ -105,14 +105,14 @@ export class CoverageAction {
 
     if (files.length === 0) {
       if (this._settings.input.files?.includes(" ")) {
-        this.warnOrThrow([
+        this.reportOrFail([
           "No code coverage data files were found. Please check the action's inputs.",
           "NOTE: To specify multiple files, use a comma or newline separated list NOT spaces.",
           "If you are using a pattern, make sure it is correct.",
           "If you are using a file, make sure it exists.",
         ]);
       } else {
-        this.warnOrThrow([
+        this.reportOrFail([
           "No code coverage data files were found. Please check the action's inputs.",
           "If you are using a pattern, make sure it is correct.",
           "If you are using a file, make sure it exists.",
@@ -209,7 +209,7 @@ export class CoverageAction {
 
   outputCoverageError(qltyOutput: string, error: unknown): void {
     if (qltyOutput) {
-      this.warnOrThrow([
+      this.reportOrFail([
         `Error executing coverage command. Output from the Qlty CLI follows:`,
         qltyOutput,
       ]);
@@ -222,7 +222,7 @@ export class CoverageAction {
         errorMessage = error;
       }
 
-      this.warnOrThrow([
+      this.reportOrFail([
         `Unexpected error executing coverage command:`,
         errorMessage,
       ]);
@@ -233,7 +233,7 @@ export class CoverageAction {
     const errors = this._settings.validate();
 
     if (errors.length > 0) {
-      this.warnOrThrow([
+      this.reportOrFail([
         "Error validating action input:",
         ...errors,
         "Please check the action's inputs.",
@@ -244,10 +244,10 @@ export class CoverageAction {
     return true;
   }
 
-  warnOrThrow(messages: string[]): void {
+  reportOrFail(messages: string[]): void {
     if (this._settings.input.skipErrors) {
       for (const message of messages) {
-        this._output.warning(message);
+        this._output.error(message);
       }
     } else {
       throw new CoverageError(messages.join("; "));

--- a/coverage/src/settings.ts
+++ b/coverage/src/settings.ts
@@ -181,7 +181,6 @@ export class Settings {
         { name: "name", value: this._data.name !== undefined },
         { name: "skip-missing-files", value: this._data.skipMissingFiles },
         { name: "format", value: this._data.format !== undefined },
-        { name: "validate", value: this._data.validate },
         {
           name: "validate-file-threshold",
           value: this._data.validateFileThreshold !== undefined,

--- a/coverage/src/settings.ts
+++ b/coverage/src/settings.ts
@@ -176,7 +176,6 @@ export class Settings {
         { name: "files", value: this._data.files !== undefined },
         { name: "add-prefix", value: this._data.addPrefix !== undefined },
         { name: "strip-prefix", value: this._data.stripPrefix !== undefined },
-        { name: "dry-run", value: this._data.dryRun },
         { name: "incomplete", value: this._data.incomplete },
         { name: "name", value: this._data.name !== undefined },
         { name: "skip-missing-files", value: this._data.skipMissingFiles },

--- a/coverage/src/util/output.ts
+++ b/coverage/src/util/output.ts
@@ -4,6 +4,7 @@ export interface ActionOutput {
   setFailed(message: string): void;
   info(message: string): void;
   warning(message: string): void;
+  error(message: string): void;
 }
 
 export class StubbedOutput implements ActionOutput {
@@ -11,6 +12,7 @@ export class StubbedOutput implements ActionOutput {
   paths: string[] = [];
   failures: string[] = [];
   infos: string[] = [];
+  errors: string[] = [];
   warnings: string[] = [];
 
   addPath(path: string): void {
@@ -31,5 +33,9 @@ export class StubbedOutput implements ActionOutput {
 
   warning(message: string): void {
     this.warnings.push(message);
+  }
+
+  error(message: string): void {
+    this.errors.push(message);
   }
 }

--- a/coverage/tests/action.test.ts
+++ b/coverage/tests/action.test.ts
@@ -404,6 +404,30 @@ describe("CoverageAction", () => {
       );
     });
 
+    test("does not fail when validate flag is true with complete command", async () => {
+      // Since validate defaults to true in action.yml, it should be ignored for complete command
+      // rather than causing a validation error
+      const { action, commands, output } = createTrackedAction({
+        settings: Settings.createNull({
+          "coverage-token": "qltcp_1234567890",
+          command: "complete",
+          validate: true,
+        }),
+        context: { payload: {} },
+      });
+
+      await action.run();
+
+      expect(output.warnings).toEqual([]);
+
+      const executedCommands = commands.clear();
+      expect(executedCommands.length).toBe(1);
+      const command = executedCommands[0];
+      expect(command?.command).toEqual(["qlty", "coverage", "complete"]);
+      expect(command?.command).not.toContain("--validate");
+      expect(command?.command).not.toContain("--no-validate");
+    });
+
     test("throws an error if qlty fails when skip-errors is false", async () => {
       const { action } = createTrackedAction({
         executor: new StubbedCommandExecutor({ throwError: true }),

--- a/coverage/tests/action.test.ts
+++ b/coverage/tests/action.test.ts
@@ -20,7 +20,7 @@ describe("CoverageAction", () => {
       });
 
       await action.run();
-      expect(output.warnings).toEqual([
+      expect(output.errors).toEqual([
         "Error validating action input:",
         "Either 'oidc' or 'token' must be provided.",
         "Please check the action's inputs.",
@@ -43,7 +43,7 @@ describe("CoverageAction", () => {
       });
 
       await action.run();
-      expect(output.warnings).toEqual([
+      expect(output.errors).toEqual([
         "Unexpected error executing coverage command:",
         "Crazy unknown error condition happened",
       ]);
@@ -79,7 +79,7 @@ describe("CoverageAction", () => {
       });
 
       await action.run();
-      expect(output.warnings).toEqual([
+      expect(output.errors).toEqual([
         "No code coverage data files were found. Please check the action's inputs.",
         "If you are using a pattern, make sure it is correct.",
         "If you are using a file, make sure it exists.",
@@ -299,7 +299,7 @@ describe("CoverageAction", () => {
       const command = executedCommands[0];
       expect(command?.command).toContain("--dry-run");
       expect(command?.env?.["QLTY_COVERAGE_TOKEN"]).toBeUndefined();
-      expect(output.warnings.length).toBe(0); // No warnings should be generated
+      expect(output.errors.length).toBe(0); // No warnings should be generated
     });
   });
 
@@ -418,7 +418,7 @@ describe("CoverageAction", () => {
 
       await action.run();
 
-      expect(output.warnings).toEqual([]);
+      expect(output.errors).toEqual([]);
 
       const executedCommands = commands.clear();
       expect(executedCommands.length).toBe(1);
@@ -452,7 +452,7 @@ describe("CoverageAction", () => {
       });
 
       await action.run();
-      expect(output.warnings).toEqual([
+      expect(output.errors).toEqual([
         "Error executing coverage command. Output from the Qlty CLI follows:",
         "STDOUT\nSTDERR\n",
       ]);
@@ -484,7 +484,7 @@ describe("CoverageAction", () => {
       });
 
       await action.run();
-      expect(output.warnings).toEqual([
+      expect(output.errors).toEqual([
         "Error executing coverage command. Output from the Qlty CLI follows:",
         "STDOUT\nSTDERR\n",
       ]);
@@ -501,7 +501,7 @@ describe("CoverageAction", () => {
       });
 
       await action.run();
-      expect(output.warnings).toEqual([
+      expect(output.errors).toEqual([
         "Error installing Qlty CLI: download error. Please check the action's inputs. If you are using a 'cli-version', make sure it is correct.",
       ]);
     });
@@ -519,7 +519,7 @@ describe("CoverageAction", () => {
       });
 
       await action.run();
-      expect(output.warnings).toEqual([
+      expect(output.errors).toEqual([
         "No code coverage data files were found. Please check the action's inputs.",
         "NOTE: To specify multiple files, use a comma or newline separated list NOT spaces.",
         "If you are using a pattern, make sure it is correct.",

--- a/coverage/tests/settings.test.ts
+++ b/coverage/tests/settings.test.ts
@@ -470,9 +470,6 @@ describe("Settings", () => {
           "'total-parts-count' cannot be used when command is 'complete'.",
         );
         expect(errors).toContain(
-          "'dry-run' cannot be used when command is 'complete'.",
-        );
-        expect(errors).toContain(
           "'incomplete' cannot be used when command is 'complete'.",
         );
         expect(errors).toContain(

--- a/coverage/tests/settings.test.ts
+++ b/coverage/tests/settings.test.ts
@@ -478,7 +478,8 @@ describe("Settings", () => {
         expect(errors).toContain(
           "'name' cannot be used when command is 'complete'.",
         );
-        expect(errors).toContain(
+        // validate is no longer an error since it defaults to true and is just ignored
+        expect(errors).not.toContain(
           "'validate' cannot be used when command is 'complete'.",
         );
         expect(errors).toContain(


### PR DESCRIPTION
We recently changed the default of the `validate` input from `false` to `true`. Unfortunately this had the side effect of including `validate` for the `complete` command, which is an invalid configuration, causing the coverage complete command to error.

This PR ignores the `validate` option completely rather than raising an error if it has a truthy value.

This PR also :
- changes the log level to **error** instead of **warning** when something is broken enough that it would ordinarily fail the action (but does not if skip-errors is set to true).
- allows using the `dry-run` option for `complete` since that's a valid argument for `complete`