### PR TITLE
ci: Add --ignore-scripts flag to npm install commands

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install Dependencies
         working-directory: ./coverage
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Test
         working-directory: ./coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install Dependencies
         working-directory: ./fmt
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build dist/ Directory
         working-directory: ./fmt
@@ -74,7 +74,7 @@ jobs:
 
       - name: Install Dependencies
         working-directory: ./coverage
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build dist/ Directory
         working-directory: ./coverage
@@ -122,7 +122,7 @@ jobs:
 
       - name: Install Dependencies
         working-directory: ./coverage
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Test
         working-directory: ./coverage


### PR DESCRIPTION
## Summary
- Add `--ignore-scripts` flag to npm ci/install commands in CI workflows

## Rationale
This prevents npm from executing any lifecycle scripts (including postinstall) during dependency installation, reducing the attack surface from malicious packages.

## Test plan
- [ ] CI workflows still pass
- [ ] Dependencies are installed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)