### PR TITLE
fix: Stop passing deprecated --validate flag to CLI

### DIFF
--- a/coverage/dist/index.js
+++ b/coverage/dist/index.js
@@ -74310,7 +74310,6 @@ var CoverageAction = class _CoverageAction {
       uploadArgs.push("--name", this._settings.input.name);
     }
     if (this._settings.input.validate) {
-      uploadArgs.push("--validate");
       if (this._settings.input.validateFileThreshold) {
         uploadArgs.push(
           "--validate-file-threshold",

--- a/coverage/src/action.ts
+++ b/coverage/src/action.ts
@@ -328,8 +328,6 @@ export class CoverageAction {
     }
 
     if (this._settings.input.validate) {
-      uploadArgs.push("--validate");
-
       if (this._settings.input.validateFileThreshold) {
         uploadArgs.push(
           "--validate-file-threshold",

--- a/coverage/tests/action.test.ts
+++ b/coverage/tests/action.test.ts
@@ -226,23 +226,6 @@ describe("CoverageAction", () => {
       expect(command?.command).toContain("custom-name");
     });
 
-    test("adds validate flag when validate is true", async () => {
-      const { action, commands } = createTrackedAction({
-        settings: Settings.createNull({
-          "coverage-token": "qltcp_1234567890",
-          files: "info.lcov",
-          validate: true,
-        }),
-        context: { payload: {} },
-      });
-      await action.run();
-
-      const executedCommands = commands.clear();
-      expect(executedCommands.length).toBe(1);
-      const command = executedCommands[0];
-      expect(command?.command).toContain("--validate");
-    });
-
     test("adds --output-dir when RUNNER_TEMP env var is present", async () => {
       const { action, commands } = createTrackedAction({
         settings: Settings.createNull({
@@ -276,7 +259,7 @@ describe("CoverageAction", () => {
       const executedCommands = commands.clear();
       expect(executedCommands.length).toBe(1);
       const command = executedCommands[0];
-      expect(command?.command).toContain("--validate");
+      expect(command?.command).not.toContain("--validate");
       expect(command?.command).toContain("--validate-file-threshold");
       expect(command?.command).toContain("80");
     });


### PR DESCRIPTION
## Summary
- Remove the `--validate` flag from being passed to the qlty CLI when `validate: true` is set, since it is deprecated and is now the default CLI behavior
- `--no-validate` and `--validate-file-threshold` continue to be passed as before

## Test plan
- [x] All existing tests pass (80/80)
- [ ] Verify coverage publish works without the `--validate` flag in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)