### PR TITLE
Automate changelog drafting in the release process

### DIFF
--- a/.github/prompts/changelog.md
+++ b/.github/prompts/changelog.md
@@ -1,0 +1,38 @@
+# Draft a changelog entry for an upcoming release
+
+You are drafting the CHANGELOG.md entry for an upcoming release of this
+repository. The workflow invoking you provides three values:
+
+- `VERSION`: the version being released, without a leading "v"
+- `LAST_TAG`: the git tag of the most recent release
+- `DATE`: today's date (YYYY-MM-DD)
+
+Follow these steps:
+
+1. Use `git log ${LAST_TAG}..HEAD --oneline --first-parent` to list the
+   changes merged since the last release. (If a change was not made through a
+   pull request, you can safely skip it.)
+2. For each merged pull request, retrieve the PR title and description from
+   GitHub for additional context using `gh pr view`.
+3. Ignore changes which are chores, docs only, CI changes, tests only,
+   style/formatting changes, build pipeline changes, and routine dependency
+   bumps that don't change the published action's behavior. The CHANGELOG.md
+   only contains changes which are externally observable new features,
+   enhancements, and fixes. (A dependency update that fixes a security
+   vulnerability in the published action counts as a fix.)
+4. Add exactly one new section to the top of CHANGELOG.md, directly below the
+   `# Changelog` heading: `## v${VERSION} (${DATE})`. Follow the existing
+   format of the file — group changes under `### New`, `### Improved`, and
+   `### Fixed` subheadings when there is more than one kind of change, and
+   reference PR numbers like `(#125)`.
+5. If there are no externally observable changes, still add the section with a
+   single brief bullet summarizing the most significant internal change.
+6. If a PR author is not a member of the team, include a shout out thanking
+   them. (Team members are @noahd1, @lsegal, @brynary, @marschattha,
+   @davehenton, @laura-mlg. They don't need shout outs.)
+
+Rules:
+
+- Only edit CHANGELOG.md, and only add the single new section. Do not reword
+  or reorganize existing entries.
+- Do not commit, push, or open pull requests; the workflow handles that.

--- a/.github/prompts/changelog.md
+++ b/.github/prompts/changelog.md
@@ -28,7 +28,7 @@ Follow these steps:
 5. If there are no externally observable changes, still add the section with a
    single brief bullet summarizing the most significant internal change.
 6. If a PR author is not a member of the team, include a shout out thanking
-   them. (Team members are @noahd1, @lsegal, @brynary, @marschattha,
+   them. (Team members are @noahd1, @brynary, @marschattha,
    @davehenton, @laura-mlg. They don't need shout outs.)
 
 Rules:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -224,5 +224,4 @@ jobs:
             --head "release/v${VERSION}" \
             --base main \
             --title "Release v${VERSION}" \
-            --label release \
             --body-file pr_body.md

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,228 @@
+name: Prepare Release
+on:
+  workflow_dispatch:
+    inputs:
+      increment:
+        description: "How to increment version (use 'version' to specify version)"
+        required: true
+        type: choice
+        default: minor
+        options:
+          - major
+          - minor
+          - patch
+          - version
+      version:
+        description: >
+          The full version to release (first choose 'version' from the
+          'increment' dropdown)
+        required: false
+        type: string
+permissions:
+  contents: read
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # version 2.0.6
+        id: app-token
+        with:
+          app-id: ${{ vars.QLTY_APP_ID }}
+          private-key: ${{ secrets.QLTY_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # version 4.2.2
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+
+      - name: Determine version
+        id: version
+        run: |
+          # Get current version from package.json
+          CURRENT_VERSION=$(node -p "require('./coverage/package.json').version")
+          echo "Current version: $CURRENT_VERSION"
+
+          # Determine new version based on input
+          if [ "${{ inputs.increment }}" == "version" ]; then
+            if [ -z "${{ inputs.version }}" ]; then
+              echo "Error: Version must be specified when increment is 'version'"
+              exit 1
+            fi
+            NEW_VERSION="${{ inputs.version }}"
+          else
+            # Parse current version
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+            case "${{ inputs.increment }}" in
+              major)
+                NEW_VERSION="$((MAJOR + 1)).0.0"
+                ;;
+              minor)
+                NEW_VERSION="${MAJOR}.$((MINOR + 1)).0"
+                ;;
+              patch)
+                NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+                ;;
+              *)
+                echo "Error: Invalid increment type"
+                exit 1
+                ;;
+            esac
+          fi
+
+          LAST_TAG=$(git tag --list 'v*' --sort=-version:refname \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1)
+
+          echo "New version: $NEW_VERSION (last release tag: $LAST_TAG)"
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "last_tag=$LAST_TAG" >> "$GITHUB_OUTPUT"
+          echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Check version is unreleased
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          if git rev-parse -q --verify "refs/tags/v${VERSION}" > /dev/null; then
+            echo "Error: Tag v${VERSION} already exists"
+            exit 1
+          fi
+
+          if grep -q "^## v${VERSION} " CHANGELOG.md; then
+            echo "Error: CHANGELOG.md already has an entry for v${VERSION}"
+            exit 1
+          fi
+
+          if git ls-remote --exit-code origin "refs/heads/release/v${VERSION}" > /dev/null; then
+            echo "Error: Branch release/v${VERSION} already exists."
+            echo "Close its pull request and delete the branch to re-prepare this release."
+            exit 1
+          fi
+
+      - name: Update package.json versions
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          for package_file in coverage/package.json fmt/package.json; do
+            echo "Updating version in $package_file to $VERSION"
+            node -e "
+              const fs = require('fs');
+              const pkg = JSON.parse(fs.readFileSync('$package_file', 'utf8'));
+              pkg.version = '$VERSION';
+              fs.writeFileSync('$package_file', JSON.stringify(pkg, null, 2) + '\\n');
+            "
+          done
+
+      - name: Draft changelog entry
+        uses: anthropics/claude-code-action@493279a9d94b7cc5d07a98e5e66cb03313805350 # version 1.0.166
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          prompt: |
+            Follow the instructions in .github/prompts/changelog.md with these values:
+
+            VERSION: ${{ steps.version.outputs.version }}
+            LAST_TAG: ${{ steps.version.outputs.last_tag }}
+            DATE: ${{ steps.version.outputs.date }}
+          claude_args: >-
+            --allowedTools "Read,Grep,Glob,Edit(CHANGELOG.md),Write(CHANGELOG.md),Bash(git log:*),Bash(git show:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh release list:*)"
+
+      - name: Validate drafted changes
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          if ! grep -q "^## v${VERSION} " CHANGELOG.md; then
+            echo "Error: No '## v${VERSION}' entry was added to CHANGELOG.md"
+            exit 1
+          fi
+
+          # Only the changelog and package.json version bumps may change
+          git status --porcelain | while read -r _status file; do
+            case "$file" in
+              CHANGELOG.md|coverage/package.json|fmt/package.json) ;;
+              *)
+                echo "Error: Unexpected change to $file"
+                exit 1
+                ;;
+            esac
+          done
+
+          # Extract the new entry for the PR body
+          awk "/^## v${VERSION} /{flag=1; next} /^## v[0-9]/{flag=0} flag" \
+            CHANGELOG.md > changelog_entry.txt
+
+          echo "Drafted changelog entry:"
+          cat changelog_entry.txt
+
+      - name: Create release branch with signed commit
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          BRANCH="release/v${VERSION}"
+          HEAD_SHA=$(git rev-parse HEAD)
+
+          gh api \
+            --method POST \
+            /repos/${{ github.repository }}/git/refs \
+            -f ref="refs/heads/${BRANCH}" \
+            -f sha="$HEAD_SHA"
+
+          # createCommitOnBranch produces a commit signed by the GitHub App
+          gh api graphql \
+            -f query='
+              mutation($repo: String!, $branch: String!, $head: GitObjectID!, $message: String!, $changelog: Base64String!, $coverage: Base64String!, $fmt: Base64String!) {
+                createCommitOnBranch(input: {
+                  branch: {repositoryNameWithOwner: $repo, branchName: $branch},
+                  expectedHeadOid: $head,
+                  message: {headline: $message},
+                  fileChanges: {additions: [
+                    {path: "CHANGELOG.md", contents: $changelog},
+                    {path: "coverage/package.json", contents: $coverage},
+                    {path: "fmt/package.json", contents: $fmt}
+                  ]}
+                }) { commit { oid } }
+              }' \
+            -f repo="${{ github.repository }}" \
+            -f branch="$BRANCH" \
+            -f head="$HEAD_SHA" \
+            -f message="Prepare release v${VERSION}" \
+            -f changelog="$(base64 -w0 CHANGELOG.md)" \
+            -f coverage="$(base64 -w0 coverage/package.json)" \
+            -f fmt="$(base64 -w0 fmt/package.json)"
+
+      - name: Open release pull request
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          {
+            echo "Automated release preparation for v${VERSION}."
+            echo
+            echo "Review (and edit, if needed) the changelog entry below, then"
+            echo "merge this pull request to tag and publish the release."
+            echo
+            echo "## Draft release notes"
+            echo
+            cat changelog_entry.txt
+          } > pr_body.md
+
+          gh pr create \
+            --head "release/v${VERSION}" \
+            --base main \
+            --title "Release v${VERSION}" \
+            --label release \
+            --body-file pr_body.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,17 +9,15 @@ permissions:
 jobs:
   release:
     # Runs when a release pull request is merged, or on manual dispatch as
-    # a fallback. A release pull request must come from a release/* branch
-    # (whose creation is restricted to maintainers and the release app by a
-    # ruleset) AND carry the "release" label, as set up by the Prepare
-    # Release workflow. Either way, the version comes from the package.json
-    # files on the released commit.
+    # a fallback. A release pull request is one from a release/* branch,
+    # whose creation is restricted to maintainers and the release app by a
+    # ruleset. Either way, the version comes from the package.json files on
+    # the released commit.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true &&
        github.event.pull_request.base.ref == github.event.repository.default_branch &&
-       startsWith(github.event.pull_request.head.ref, 'release/') &&
-       contains(github.event.pull_request.labels.*.name, 'release'))
+       startsWith(github.event.pull_request.head.ref, 'release/'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # version 2.0.6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,14 +8,17 @@ permissions:
   contents: write
 jobs:
   release:
-    # Runs when a release pull request (opened by the Prepare Release
-    # workflow, labeled "release") is merged, or on manual dispatch as a
-    # fallback. Either way, the version comes from the package.json files
-    # on the released commit.
+    # Runs when a release pull request is merged, or on manual dispatch as
+    # a fallback. A release pull request must come from a release/* branch
+    # (whose creation is restricted to maintainers and the release app by a
+    # ruleset) AND carry the "release" label, as set up by the Prepare
+    # Release workflow. Either way, the version comes from the package.json
+    # files on the released commit.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true &&
        github.event.pull_request.base.ref == github.event.repository.default_branch &&
+       startsWith(github.event.pull_request.head.ref, 'release/') &&
        contains(github.event.pull_request.labels.*.name, 'release'))
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,30 +1,25 @@
 name: Release
 on:
+  pull_request:
+    types:
+      - closed
   workflow_dispatch:
-    inputs:
-      increment:
-        description: "How to increment version (use 'version' to specify version)"
-        required: true
-        type: choice
-        default: minor
-        options:
-          - major
-          - minor
-          - patch
-          - version
-      version:
-        description: >
-          The full version to release (first choose 'version' from the
-          'increment' dropdown)
-        required: false
-        type: string
 permissions:
   contents: write
 jobs:
   release:
+    # Runs when a release pull request (opened by the Prepare Release
+    # workflow, labeled "release") is merged, or on manual dispatch as a
+    # fallback. Either way, the version comes from the package.json files
+    # on the released commit.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       github.event.pull_request.base.ref == github.event.repository.default_branch &&
+       contains(github.event.pull_request.labels.*.name, 'release'))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # veresion 2.0.6
+      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # version 2.0.6
         id: app-token
         with:
           app-id: ${{ vars.QLTY_APP_ID }}
@@ -35,52 +30,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # version 4.2.2
         with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.ref }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .node-version
 
       - name: Determine version
         id: version
         run: |
-          # Get current version from package.json
-          CURRENT_VERSION=$(node -p "require('./coverage/package.json').version")
-          echo "Current version: $CURRENT_VERSION"
+          VERSION=$(node -p "require('./coverage/package.json').version")
+          FMT_VERSION=$(node -p "require('./fmt/package.json').version")
 
-          # Determine new version based on input
-          if [ "${{ inputs.increment }}" == "version" ]; then
-            if [ -z "${{ inputs.version }}" ]; then
-              echo "Error: Version must be specified when increment is 'version'"
-              exit 1
-            fi
-            NEW_VERSION="${{ inputs.version }}"
-          else
-            # Parse current version
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-
-            case "${{ inputs.increment }}" in
-              major)
-                NEW_VERSION="$((MAJOR + 1)).0.0"
-                ;;
-              minor)
-                NEW_VERSION="${MAJOR}.$((MINOR + 1)).0"
-                ;;
-              patch)
-                NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
-                ;;
-              *)
-                echo "Error: Invalid increment type"
-                exit 1
-                ;;
-            esac
+          if [ "$VERSION" != "$FMT_VERSION" ]; then
+            echo "Error: coverage/package.json ($VERSION) and fmt/package.json ($FMT_VERSION) disagree"
+            exit 1
           fi
 
-          echo "New version: $NEW_VERSION"
-          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-          echo "major_version=$(echo $NEW_VERSION | cut -d. -f1)" >> "$GITHUB_OUTPUT"
+          if git rev-parse -q --verify "refs/tags/v${VERSION}" > /dev/null; then
+            echo "Error: Tag v${VERSION} already exists"
+            exit 1
+          fi
+
+          echo "Releasing version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "major_version=$(echo $VERSION | cut -d. -f1)" >> "$GITHUB_OUTPUT"
 
       - name: Validate CHANGELOG.md
         run: |
@@ -117,87 +89,24 @@ jobs:
           echo "Extracted changelog content:"
           cat changelog_content.txt
 
-      - name: Validate required package.json files exist
+      - name: Check for changes merged after release preparation
+        if: github.event_name == 'pull_request'
         run: |
-          # Check that required package.json files exist
-          MISSING_FILES=""
+          MERGE_SHA="${{ github.event.pull_request.merge_commit_sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
 
-          if [ ! -f "coverage/package.json" ]; then
-            MISSING_FILES="${MISSING_FILES}coverage/package.json "
+          if ! git cat-file -e "$HEAD_SHA" 2> /dev/null; then
+            echo "Release branch head $HEAD_SHA is no longer reachable; skipping staleness check"
+            exit 0
           fi
 
-          if [ ! -f "fmt/package.json" ]; then
-            MISSING_FILES="${MISSING_FILES}fmt/package.json "
+          BRANCH_POINT=$(git merge-base "$HEAD_SHA" "${MERGE_SHA}^")
+          MISSED=$(git log --oneline --first-parent "${BRANCH_POINT}..${MERGE_SHA}^")
+
+          if [ -n "$MISSED" ]; then
+            echo "::warning::Commits landed on the default branch after this release was prepared. Verify the changelog covers them:"
+            echo "$MISSED"
           fi
-
-          if [ -n "$MISSING_FILES" ]; then
-            echo "Error: Required package.json files are missing: $MISSING_FILES"
-            exit 1
-          fi
-
-          echo "All required package.json files exist"
-
-      - name: Update package.json versions
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-
-          # Update all package.json files
-          for package_file in coverage/package.json fmt/package.json; do
-            echo "Updating version in $package_file to $VERSION"
-            node -e "
-              const fs = require('fs');
-              const pkg = JSON.parse(fs.readFileSync('$package_file', 'utf8'));
-              pkg.version = '$VERSION';
-              fs.writeFileSync('$package_file', JSON.stringify(pkg, null, 2) + '\\n');
-            "
-          done
-
-          # Show the changes
-          git diff coverage/package.json fmt/package.json || true
-
-      - name: Commit version changes via GitHub API
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-
-          # Update coverage/package.json via API
-          COVERAGE_CONTENT=$(base64 < coverage/package.json)
-          gh api \
-            --method PUT \
-            /repos/${{ github.repository }}/contents/coverage/package.json \
-            -f message="Release v${VERSION} - Update coverage package.json" \
-            -f content="$COVERAGE_CONTENT" \
-            -f sha="$(git rev-parse HEAD:coverage/package.json)"
-
-          echo "Updated coverage/package.json"
-
-          # Discard local changes since they've been committed via API
-          git checkout -- coverage/package.json
-
-          # Update fmt/package.json via API if it exists
-          if [ -f "fmt/package.json" ]; then
-            # Pull latest to get the new SHA after first commit
-            git pull origin ${{ github.ref_name }}
-
-            FMT_CONTENT=$(base64 < fmt/package.json)
-            gh api \
-              --method PUT \
-              /repos/${{ github.repository }}/contents/fmt/package.json \
-              -f message="Release v${VERSION} - Update fmt package.json" \
-              -f content="$FMT_CONTENT" \
-              -f sha="$(git rev-parse HEAD:fmt/package.json)"
-
-            echo "Updated fmt/package.json"
-
-            # Discard local changes since they've been committed via API
-            git checkout -- fmt/package.json
-          fi
-
-          # Pull the latest changes
-          git pull origin ${{ github.ref_name }}
-
-          echo "Created signed commits for version ${VERSION}"
 
       - name: Create and push tags via GitHub API
         env:

--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -96,3 +96,10 @@ set.ignored = true
 match.file_patterns = [".github/workflows/*"]
 match.rules = ["yamllint:line-length"]
 set.ignored = true
+
+# Prettier normalizes inline comments to one leading space, which conflicts
+# with yamllint's default two-space requirement
+[[triage]]
+match.file_patterns = [".github/workflows/*"]
+match.rules = ["yamllint:comments"]
+set.ignored = true


### PR DESCRIPTION
## Summary

Splits the release process into a prepare phase (LLM-drafted changelog, human-reviewed via PR) and a publish phase (tag + GitHub Release on merge).

### New: Prepare Release workflow

- Manual dispatch with the same `increment`/`version` inputs the old Release workflow had
- Computes the next version, bumps `coverage/package.json` and `fmt/package.json`
- Drafts the `CHANGELOG.md` entry with Claude (`anthropics/claude-code-action`), following the checked-in prompt at `.github/prompts/changelog.md` (adapted from qltysh/qlty's changelog prompt, scoped to a single new version entry)
- Validates the draft (entry header present; only CHANGELOG.md + the two package.json files changed)
- Creates a `release/v{VERSION}` branch with an app-signed commit (GraphQL `createCommitOnBranch`) and opens a PR for human review

### Changed: Release workflow now publishes only

- Triggered by merging a PR from a `release/*` branch (or manual dispatch as fallback) — branch creation under `release/` is restricted by ruleset, so the trigger is tied to protected provenance
- Reads the version from `coverage/package.json` on the released commit (no inputs), checks the two package.json versions agree, and keeps the existing changelog-entry validation as a safety net
- Warns if commits landed on main after the release was prepared (possible changelog gaps)
- Tags `v{VERSION}` + major `v{N}` and creates the GitHub Release, as before
- The commit-via-contents-API version bump steps are gone — the reviewed release PR already contains the version bumps, so the tag always points at exactly what was reviewed

### Also in this PR

- `.qlty/qlty.toml`: triage-ignore `yamllint:comments` for workflow files (prettier normalizes inline comments to one leading space; yamllint demands two)

### Repo settings changed out-of-band (already live)

- Created branch ruleset "Only maintainers manage release branches" restricting creation/update/deletion of `release/**` to the Maintain role and the qlty-releases app (mirrors the existing tag ruleset)

## Prerequisite before first use

- `ANTHROPIC_API_KEY` secret must be available to this repo (I could not verify org-level secrets). Add it if missing, or the "Draft changelog entry" step will fail.

## Test plan

- [ ] Run "Prepare Release" with a patch increment; confirm it opens a labeled release PR with a sensible drafted changelog entry and version bumps
- [ ] Edit the changelog entry on the PR branch (as a maintainer) to confirm the ruleset bypass works
- [ ] Merge the release PR; confirm the Release workflow tags and publishes with the reviewed notes
- [ ] Confirm a non-maintainer cannot create a `release/*` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

