### PR TITLE
Announce releases to #feed-deploys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,28 +168,46 @@ jobs:
             --notes-file changelog_content.txt \
             --verify-tag
 
+      - name: Compose Slack announcement
+        id: compose
+        run: |
+          cat > slack_announcement.json <<'EOF'
+          {
+            "text": ":rocket: qlty-action <${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ steps.version.outputs.version }}|v${{ steps.version.outputs.version }}> released (previous version: ${{ steps.version.outputs.previous_tag }})",
+            "attachments": [
+              {
+                "color": "#2eb886",
+                "blocks": [
+                  {
+                    "type": "context",
+                    "elements": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "by ${{ github.actor }} · <${{ steps.version.outputs.full_changelog_url }}|full changelog> · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run #${{ github.run_number }}>"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+          EOF
+
+          cat slack_announcement.json
+
       - name: Announce release to Slack (#feed-deploys)
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
-          payload: |
-            {
-              "text": ":rocket: qlty-action <${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ steps.version.outputs.version }}|v${{ steps.version.outputs.version }}> released (previous version: ${{ steps.version.outputs.previous_tag }})",
-              "attachments": [
-                {
-                  "color": "#2eb886",
-                  "blocks": [
-                    {
-                      "type": "context",
-                      "elements": [
-                        {
-                          "type": "mrkdwn",
-                          "text": "by ${{ github.actor }} · <${{ steps.version.outputs.full_changelog_url }}|full changelog> · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run #${{ github.run_number }}>"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+          payload-file-path: slack_announcement.json
+
+      - name: Announce release to Slack (#cust-public)
+        # Runs as long as the release was published (compose succeeded),
+        # even if the #feed-deploys announcement failed
+        if: ${{ !cancelled() && steps.compose.conclusion == 'success' }}
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_CUST_PUBLIC_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload-file-path: slack_announcement.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
                       "elements": [
                         {
                           "type": "mrkdwn",
-                          "text": "by ${{ github.actor }} · <${{ github.server_url }}/${{ github.repository }}/blob/v${{ steps.version.outputs.version }}/CHANGELOG.md|changelog> · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run #${{ github.run_number }}>"
+                          "text": "by ${{ github.actor }} · <${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ steps.version.outputs.version }}|changelog> · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run #${{ github.run_number }}>"
                         }
                       ]
                     }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,24 +162,23 @@ jobs:
       - name: Announce release to Slack (#feed-deploys)
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
-          webhook: ${{ secrets.SLACK_FEED_DEPLOYS_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             {
-              "blocks": [
+              "text": ":rocket: qlty-action <${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ steps.version.outputs.version }}|v${{ steps.version.outputs.version }}> released (previous version: ${{ steps.version.outputs.previous_tag }})",
+              "attachments": [
                 {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "🚀 New *qlty-action* release: <${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ steps.version.outputs.version }}|v${{ steps.version.outputs.version }}> (previous version: ${{ steps.version.outputs.previous_tag }})"
-                  }
-                },
-                {
-                  "type": "context",
-                  "elements": [
+                  "color": "#2eb886",
+                  "blocks": [
                     {
-                      "type": "mrkdwn",
-                      "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
+                      "type": "context",
+                      "elements": [
+                        {
+                          "type": "mrkdwn",
+                          "text": "by ${{ github.actor }} · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run #${{ github.run_number }}>"
+                        }
+                      ]
                     }
                   ]
                 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,15 @@ jobs:
           echo "major_version=$(echo $VERSION | cut -d. -f1)" >> "$GITHUB_OUTPUT"
           echo "previous_tag=${PREVIOUS_TAG:-none}" >> "$GITHUB_OUTPUT"
 
+          # For the Slack announcement: a compare URL between the previous
+          # and new tags, falling back to the release page on a first release
+          if [ -n "$PREVIOUS_TAG" ]; then
+            FULL_CHANGELOG_URL="${{ github.server_url }}/${{ github.repository }}/compare/${PREVIOUS_TAG}...v${VERSION}"
+          else
+            FULL_CHANGELOG_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/v${VERSION}"
+          fi
+          echo "full_changelog_url=$FULL_CHANGELOG_URL" >> "$GITHUB_OUTPUT"
+
       - name: Validate CHANGELOG.md
         run: |
           VERSION="${{ steps.version.outputs.version }}"
@@ -176,7 +185,7 @@ jobs:
                       "elements": [
                         {
                           "type": "mrkdwn",
-                          "text": "by ${{ github.actor }} · <${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ steps.version.outputs.version }}|changelog> · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run #${{ github.run_number }}>"
+                          "text": "by ${{ github.actor }} · <${{ steps.version.outputs.full_changelog_url }}|full changelog> · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run #${{ github.run_number }}>"
                         }
                       ]
                     }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
                       "elements": [
                         {
                           "type": "mrkdwn",
-                          "text": "by ${{ github.actor }} · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run #${{ github.run_number }}>"
+                          "text": "by ${{ github.actor }} · <${{ github.server_url }}/${{ github.repository }}/blob/v${{ steps.version.outputs.version }}/CHANGELOG.md|changelog> · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run #${{ github.run_number }}>"
                         }
                       ]
                     }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,19 +56,11 @@ jobs:
           PREVIOUS_TAG=$(git tag --list 'v*' --sort=-version:refname \
             | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1)
 
-          echo "Releasing version: $VERSION (previous release: ${PREVIOUS_TAG:-none})"
+          echo "Releasing version: $VERSION (previous release: $PREVIOUS_TAG)"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "major_version=$(echo $VERSION | cut -d. -f1)" >> "$GITHUB_OUTPUT"
-          echo "previous_tag=${PREVIOUS_TAG:-none}" >> "$GITHUB_OUTPUT"
-
-          # For the Slack announcement: a compare URL between the previous
-          # and new tags, falling back to the release page on a first release
-          if [ -n "$PREVIOUS_TAG" ]; then
-            FULL_CHANGELOG_URL="${{ github.server_url }}/${{ github.repository }}/compare/${PREVIOUS_TAG}...v${VERSION}"
-          else
-            FULL_CHANGELOG_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/v${VERSION}"
-          fi
-          echo "full_changelog_url=$FULL_CHANGELOG_URL" >> "$GITHUB_OUTPUT"
+          echo "previous_tag=$PREVIOUS_TAG" >> "$GITHUB_OUTPUT"
+          echo "full_changelog_url=${{ github.server_url }}/${{ github.repository }}/compare/${PREVIOUS_TAG}...v${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Validate CHANGELOG.md
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,15 @@ jobs:
             exit 1
           fi
 
-          echo "Releasing version: $VERSION"
+          # The new tag doesn't exist yet, so the newest semver tag is the
+          # version being replaced
+          PREVIOUS_TAG=$(git tag --list 'v*' --sort=-version:refname \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1)
+
+          echo "Releasing version: $VERSION (previous release: ${PREVIOUS_TAG:-none})"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "major_version=$(echo $VERSION | cut -d. -f1)" >> "$GITHUB_OUTPUT"
+          echo "previous_tag=${PREVIOUS_TAG:-none}" >> "$GITHUB_OUTPUT"
 
       - name: Validate CHANGELOG.md
         run: |
@@ -152,3 +158,30 @@ jobs:
             --title "v${{ steps.version.outputs.version }}" \
             --notes-file changelog_content.txt \
             --verify-tag
+
+      - name: Announce release to Slack (#feed-deploys)
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_FEED_DEPLOYS_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "🚀 New *qlty-action* release: <${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ steps.version.outputs.version }}|v${{ steps.version.outputs.version }}> (previous version: ${{ steps.version.outputs.previous_tag }})"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
+                    }
+                  ]
+                }
+              ]
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,7 +183,7 @@ jobs:
                     "elements": [
                       {
                         "type": "mrkdwn",
-                        "text": "by ${{ github.actor }} · <${{ steps.version.outputs.full_changelog_url }}|full changelog> · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run #${{ github.run_number }}>"
+                        "text": "<${{ steps.version.outputs.full_changelog_url }}|full changelog>"
                       }
                     ]
                   }


### PR DESCRIPTION
Adds a final step to the Release workflow that posts to Slack after the GitHub Release is created:

> 🚀 New **qlty-action** release: v2.2.3 (previous version: v2.2.2)

with a link to the release and the workflow run. The previous version is the newest existing semver tag before the new tag is created.

Uses the same mechanism as qltysh/qltysh deploy notifications: `slackapi/slack-github-action` v2.0.0 (SHA-pinned), the shared `SLACK_WEBHOOK_URL` incoming-webhook secret, and the same payload style (top-level text + colored attachment with actor and run-link context).

## Prerequisites

Two incoming-webhook secrets, one per channel (webhooks are channel-bound):

- [ ] `SLACK_WEBHOOK_URL` — the same webhook qltysh/qltysh uses for deploy notifications (share the org secret or copy the value), posting to **#feed-deploys**
- [ ] `SLACK_CUST_PUBLIC_WEBHOOK_URL` — a webhook posting to **#cust-public**

```
gh secret set SLACK_WEBHOOK_URL -R qltysh/qlty-action
gh secret set SLACK_CUST_PUBLIC_WEBHOOK_URL -R qltysh/qlty-action
```

The announcement payload is composed once and posted to both channels. Announcements only run after the release is published; a failure posting to #feed-deploys doesn't skip #cust-public. A missing secret fails the run's announce step(s) — after the release itself has already been published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


